### PR TITLE
updated .wavefront_token and correct behavior of the file, along with added properties

### DIFF
--- a/src/main/java/com/wavefront/springboot/WavefrontConfigConditional.java
+++ b/src/main/java/com/wavefront/springboot/WavefrontConfigConditional.java
@@ -42,13 +42,30 @@ public class WavefrontConfigConditional implements Condition {
     String wavefrontProxyHost = env.getProperty(PROPERTY_FILE_KEY_WAVEFRONT_PROXY_HOST);
     @Nullable
     String wavefrontToken;
+    @Nullable
+    String wavefrontUrl;
     if (wavefrontProxyHost == null) {
       // we assume http reporting. defaults to wavefront.surf
       wavefrontToken = env.getProperty(PROPERTY_FILE_KEY_WAVEFRONT_TOKEN);
       if (wavefrontToken == null) {
         // attempt to read from local machine for the token to use.
-        Optional<String> existingToken = getWavefrontTokenFromWellKnownFile();
-        if (existingToken.isPresent()) wavefrontToken = existingToken.get();
+        Optional<String[]> existingToken = getWavefrontUriTokenFromWellKnownFile();
+        if (existingToken.isPresent()) {
+          wavefrontUrl = existingToken.get()[0];
+          wavefrontToken = existingToken.get()[1];
+          // if url from the file does not start with http, we should update it to do so
+          if (!wavefrontUrl.startsWith("http")) {
+            wavefrontUrl = env.getProperty(PROPERTY_FILE_KEY_WAVEFRONT_INSTANCE,
+                    WAVEFRONT_DEFAULT_INSTANCE);
+            if (!wavefrontUrl.startsWith("http")) {
+              wavefrontUrl = "https://" + wavefrontUrl;
+            }
+            Optional<String> written = writeWavefrontUriTokenToWellKnownFile(wavefrontUrl, wavefrontToken);
+            if(written.isPresent()) {
+              logger.info("updated " + written.get() + " with proper wavefront url");
+            }
+          }
+        }
       }
       if (wavefrontToken == null) {
         String applicationName = env.getProperty(PROPERTY_FILE_KEY_WAVEFRONT_APPLICATION,
@@ -88,7 +105,10 @@ public class WavefrontConfigConditional implements Condition {
             return false;
           }
           wavefrontToken = resp.getToken();
-          Optional<String> written = writeWavefrontTokenToWellKnownFile(wavefrontToken);
+          wavefrontUrl = resp.getUrl();   // uri which is string for initial logging in
+
+          // saving wavefrontUrl that were received
+          Optional<String> written = writeWavefrontUriTokenToWellKnownFile(wavefrontUrl, wavefrontToken);
           if (!written.isPresent()) return false;
           logger.info("Auto-negotiation of Wavefront credentials successful, stored token can be found at: " +
               written.get());
@@ -103,7 +123,17 @@ public class WavefrontConfigConditional implements Condition {
     return true;
   }
 
-  static Optional<String> writeWavefrontTokenToWellKnownFile(String token) {
+  /**
+   * <p>Change list</p>
+   * <ul>
+   *     <li>Name change to include Uri</li>
+   *     <li>Uri and token will be stored to the file, delimited by line return.</li>
+   * </ul>
+   * @param uri
+   * @param token
+   * @return Path of the absolute path fo the file created.
+   */
+  static Optional<String> writeWavefrontUriTokenToWellKnownFile(String uri, String token) {
     String userHomeStr = System.getProperty("user.home");
     if (userHomeStr == null || userHomeStr.length() == 0) {
       logger.debug("System.getProperty(\"user.home\") is empty, cannot write " +
@@ -118,12 +148,9 @@ public class WavefrontConfigConditional implements Condition {
         return Optional.empty();
       }
       File wavefrontToken = new File(userHome, WAVEFRONT_TOKEN_FILENAME);
-      if (!wavefrontToken.exists()) {
-        Files.write(Paths.get(wavefrontToken.toURI()), token.getBytes(StandardCharsets.UTF_8));
-        return Optional.of(wavefrontToken.getAbsolutePath());
-      } else {
-        return Optional.empty();
-      }
+      String data = uri + "\n" + token;
+      Files.write(Paths.get(wavefrontToken.toURI()), data.getBytes(StandardCharsets.UTF_8));
+      return Optional.of(wavefrontToken.getAbsolutePath());
     } catch (RuntimeException | IOException ex) {
       logger.warn("Cannot save Wavefront token to: " + userHomeStr + " directory. Cannot report " +
           "observability data without a valid token.", ex);

--- a/src/main/java/com/wavefront/springboot/WavefrontConfigConditional.java
+++ b/src/main/java/com/wavefront/springboot/WavefrontConfigConditional.java
@@ -56,14 +56,11 @@ public class WavefrontConfigConditional implements Condition {
           // if url from the file does not start with http, we should update it to do so
           if (!wavefrontUrl.startsWith("http")) {
             wavefrontUrl = env.getProperty(PROPERTY_FILE_KEY_WAVEFRONT_INSTANCE,
-                    WAVEFRONT_DEFAULT_INSTANCE);
+                WAVEFRONT_DEFAULT_INSTANCE);
             if (!wavefrontUrl.startsWith("http")) {
               wavefrontUrl = "https://" + wavefrontUrl;
             }
             Optional<String> written = writeWavefrontUriTokenToWellKnownFile(wavefrontUrl, wavefrontToken);
-            if(written.isPresent()) {
-              logger.info("updated " + written.get() + " with proper wavefront url");
-            }
           }
         }
       }

--- a/src/main/java/com/wavefront/springboot/WavefrontSpringBootAutoConfiguration.java
+++ b/src/main/java/com/wavefront/springboot/WavefrontSpringBootAutoConfiguration.java
@@ -8,22 +8,19 @@ import com.wavefront.sdk.common.application.ApplicationTags;
 import com.wavefront.sdk.direct.ingestion.WavefrontDirectIngestionClient;
 import com.wavefront.sdk.proxy.WavefrontProxyClient;
 import io.micrometer.core.instrument.Clock;
-import io.micrometer.core.instrument.binder.jvm.*;
-import io.micrometer.core.instrument.binder.system.*;
-import io.micrometer.core.instrument.binder.logging.*;
-import io.micrometer.core.instrument.binder.tomcat.*;
 import io.micrometer.wavefront.WavefrontConfig;
 import io.micrometer.wavefront.WavefrontMeterRegistry;
 import io.opentracing.Tracer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.autoconfigure.AutoConfigureOrder;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.web.client.RestTemplateBuilder;
-import org.springframework.context.annotation.*;
-import org.springframework.core.Ordered;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
 import org.springframework.core.env.Environment;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -45,7 +42,6 @@ import java.util.UUID;
 @PropertySource(value = "classpath:wavefront.properties", ignoreResourceNotFound = true)
 // disable entirely if enabled is not true (defaults to true).
 @ConditionalOnProperty(value = "enabled", havingValue = "true", matchIfMissing = true)
-// @AutoConfigureOrder(Ordered.HIGHEST_PRECEDENCE)
 public class WavefrontSpringBootAutoConfiguration {
 
   private static final Logger logger = LoggerFactory.getLogger(WavefrontSpringBootAutoConfiguration.class);
@@ -384,19 +380,7 @@ public class WavefrontSpringBootAutoConfiguration {
     logger.info("Activating Wavefront Spring Micrometer Reporting (connection string: " + wavefrontConfig.uri() +
         ", reporting as: " + wavefrontConfig.source() + ")");
     // create a new registry
-    WavefrontMeterRegistry registry = new WavefrontMeterRegistry(wavefrontConfig, Clock.SYSTEM);
-    /* optional registry that you can pre-set for micrometer,
-       if you want additional system metrics - Howard
-
-    new ClassLoaderMetrics().bindTo(registry);
-    new JvmMemoryMetrics().bindTo(registry);
-    new JvmGcMetrics().bindTo(registry);
-    new ProcessorMetrics().bindTo(registry);
-    new JvmThreadMetrics().bindTo(registry);
-    new UptimeMetrics().bindTo(registry);
-    new FileDescriptorMetrics().bindTo(registry);
-    */
-    return registry;
+    return new WavefrontMeterRegistry(wavefrontConfig, Clock.SYSTEM);
   }
 
   @Bean


### PR DESCRIPTION
.wavefront_token only had the token, which.. can be ambiguous given that freemium cluster might change, or can even be in different locations. 

The new change also corrected the proper behavior of the token file. If the wavefront.properties does not exist, the subsequent start of the application with autoconfig will not re-register, but rather use the url and token contained in the .wavefront_token, so that already registered tenant can be reused.

A third thing that changed is when the new registration is required, not only the link is shown in the console, but the link can also be extracted via WavefrontConfig, so that external application can potentially notify of this to user.