### PR TITLE
Integrates with Sleuth 2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>1.8</java.version>
     <spring-boot.version>2.3.0.BUILD-SNAPSHOT</spring-boot.version>
+    <spring-cloud-sleuth.version>2.2.2.RELEASE</spring-cloud-sleuth.version>
   </properties>
 
   <modules>
@@ -172,13 +173,8 @@
       </dependency>
       <dependency>
         <groupId>com.wavefront</groupId>
-        <artifactId>wavefront-opentracing-sdk-java</artifactId>
-        <version>1.16</version>
-      </dependency>
-      <dependency>
-        <groupId>io.opentracing.contrib</groupId>
-        <artifactId>opentracing-spring-cloud-starter</artifactId>
-        <version>0.5.3</version>
+        <artifactId>wavefront-sdk-java</artifactId>
+        <version>2.2</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
@@ -197,6 +193,11 @@
             <artifactId>junit-vintage-engine</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-sleuth-core</artifactId>
+        <version>${spring-cloud-sleuth.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/wavefront-spring-boot-sample/pom.xml
+++ b/wavefront-spring-boot-sample/pom.xml
@@ -20,12 +20,6 @@
       <groupId>com.wavefront</groupId>
       <artifactId>wavefront-spring-boot-starter</artifactId>
     </dependency>
-
-    <dependency>
-      <groupId>io.opentracing.contrib</groupId>
-      <artifactId>opentracing-spring-cloud-starter</artifactId>
-      <scope>runtime</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/wavefront-spring-boot-starter/pom.xml
+++ b/wavefront-spring-boot-starter/pom.xml
@@ -21,10 +21,9 @@
       <artifactId>wavefront-spring-boot</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.wavefront</groupId>
-      <artifactId>wavefront-opentracing-sdk-java</artifactId>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-sleuth-core</artifactId>
     </dependency>
-
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-registry-wavefront</artifactId>

--- a/wavefront-spring-boot/pom.xml
+++ b/wavefront-spring-boot/pom.xml
@@ -30,10 +30,11 @@
     </dependency>
 
     <dependency>
-      <groupId>com.wavefront</groupId>
-      <artifactId>wavefront-opentracing-sdk-java</artifactId>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-sleuth-core</artifactId>
       <optional>true</optional>
     </dependency>
+
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-registry-wavefront</artifactId>
@@ -51,7 +52,18 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-webflux</artifactId>
+      <version>${spring-boot.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- TODO: figure out why IntegratedTracingTests dies on missing ReflectionWorld -->
+    <dependency>
+      <groupId>org.aspectj</groupId>
+      <artifactId>aspectjweaver</artifactId>
+      <version>1.9.5</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
-
-
 </project>

--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontSpanHandler.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontSpanHandler.java
@@ -1,0 +1,160 @@
+package com.wavefront.spring.autoconfigure;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import brave.handler.FinishedSpanHandler;
+import brave.handler.MutableSpan;
+import brave.handler.MutableSpan.AnnotationConsumer;
+import brave.handler.MutableSpan.TagConsumer;
+import brave.propagation.TraceContext;
+import com.wavefront.sdk.common.Pair;
+import com.wavefront.sdk.entities.tracing.SpanLog;
+import com.wavefront.sdk.entities.tracing.WavefrontTracingSpanSender;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import static com.wavefront.sdk.common.Constants.DEBUG_TAG_KEY;
+import static com.wavefront.sdk.common.Constants.ERROR_TAG_KEY;
+import static com.wavefront.sdk.common.Constants.SOURCE_KEY;
+import static com.wavefront.sdk.common.Constants.SPAN_LOG_KEY;
+
+/**
+ * This converts a span recorded by Brave and invokes {@link WavefrontTracingSpanSender#sendSpan}.
+ *
+ * <p>This uses a combination of conversion approaches from Wavefront projects:
+ * <ul>
+ *   <li>https://github.com/wavefrontHQ/wavefront-opentracing-sdk-java</li>
+ *   <li>https://github.com/wavefrontHQ/wavefront-proxy</li>
+ * </ul>
+ *
+ * <p>On conflict, we make a comment and prefer wavefront-opentracing-sdk-java. The rationale is
+ * wavefront-opentracing-sdk-java uses the same {@link WavefrontTracingSpanSender#sendSpan} library,
+ * so it is easier to reason with. This policy can be revisited by future maintainers.
+ *
+ * <p><em>Note:</em>UUID conversions follow the same conventions used in practice in Wavefront.
+ * Ex. https://github.com/wavefrontHQ/wavefront-opentracing-sdk-java/blob/6babf2ff95daa37452e1e8c35ae54b58b6abb50f/src/main/java/com/wavefront/opentracing/propagation/JaegerWavefrontPropagator.java#L191-L204
+ * While in practice this is not a problem, it is worth mentioning that this convention will only
+ * only result in RFC 4122 timestamp (version 1) format by accident. In other words, don't call
+ * {@link UUID#timestamp()} on UUIDs converted here, or in other Wavefront code, as it might
+ * throw.
+ */
+final class WavefrontSpanHandler extends FinishedSpanHandler {
+  private static final Log LOG = LogFactory.getLog(WavefrontSpanHandler.class);
+  // https://github.com/wavefrontHQ/wavefront-proxy/blob/3dd1fa11711a04de2d9d418e2269f0f9fb464f36/proxy/src/main/java/com/wavefront/agent/listeners/tracing/ZipkinPortUnificationHandler.java#L113-L114
+  private static final String DEFAULT_SPAN_NAME = "defaultOperation";
+
+  final WavefrontTracingSpanSender wavefrontSender;
+  final String source;
+  final List<Pair<String, String>> defaultTags;
+  final Set<String> defaultTagKeys;
+
+  WavefrontSpanHandler(WavefrontTracingSpanSender wavefrontSender, String source,
+      List<Pair<String, String>> defaultTags) {
+    this.wavefrontSender = wavefrontSender;
+    this.source = source;
+    this.defaultTags = defaultTags;
+    this.defaultTagKeys = defaultTags.stream().map(p -> p._1).collect(Collectors.toSet());
+    this.defaultTagKeys.add(SOURCE_KEY);
+  }
+
+  @Override public boolean handle(TraceContext context, MutableSpan span) {
+    UUID traceId = new UUID(context.traceIdHigh(), context.traceId());
+    UUID spanId = new UUID(0L, context.spanId());
+
+    // NOTE: wavefront-opentracing-sdk-java and wavefront-proxy differ, but we prefer the former.
+    // https://github.com/wavefrontHQ/wavefront-opentracing-sdk-java/blob/f1f08d8daf7b692b9b61dcd5bc24ca6befa8e710/src/main/java/com/wavefront/opentracing/reporting/WavefrontSpanReporter.java#L187-L190
+    // https://github.com/wavefrontHQ/wavefront-proxy/blob/3dd1fa11711a04de2d9d418e2269f0f9fb464f36/proxy/src/main/java/com/wavefront/agent/listeners/tracing/ZipkinPortUnificationHandler.java#L248-L252
+    List<UUID> parents = null;
+    if (context.parentIdAsLong() != 0L) {
+      parents = Collections.singletonList(new UUID(0L, context.parentIdAsLong()));
+    }
+    List<UUID> followsFrom = null;
+
+    // https://github.com/wavefrontHQ/wavefront-proxy/blob/3dd1fa11711a04de2d9d418e2269f0f9fb464f36/proxy/src/main/java/com/wavefront/agent/listeners/tracing/ZipkinPortUnificationHandler.java#L344-L345
+    String name = span.name();
+    if (name == null) name = DEFAULT_SPAN_NAME;
+
+    // Start and duration become 0L if unset. Any positive duration rounds up to 1 millis.
+    long start = span.startTimestamp() / 1000L, finish = span.finishTimestamp() / 1000L;
+    long duration = start != 0 && finish != 0L ? Math.max(finish - start, 1L) : 0L;
+
+    WavefrontConsumer wavefrontConsumer = new WavefrontConsumer(defaultTagKeys);
+
+    // https://github.com/wavefrontHQ/wavefront-proxy/blob/3dd1fa11711a04de2d9d418e2269f0f9fb464f36/proxy/src/main/java/com/wavefront/agent/listeners/tracing/ZipkinPortUnificationHandler.java#L397-L402
+    List<SpanLog> spanLogs = new ArrayList<>();
+    span.forEachAnnotation(wavefrontConsumer, spanLogs);
+
+    List<Pair<String, String>> tags = new ArrayList<>(defaultTags);
+    span.forEachTag(wavefrontConsumer, tags);
+
+    // https://github.com/wavefrontHQ/wavefront-proxy/blob/3dd1fa11711a04de2d9d418e2269f0f9fb464f36/proxy/src/main/java/com/wavefront/agent/listeners/tracing/ZipkinPortUnificationHandler.java#L300-L303
+    if (context.debug() || wavefrontConsumer.debug) {
+      tags.add(Pair.of(DEBUG_TAG_KEY, "true"));
+    }
+
+    // https://github.com/wavefrontHQ/wavefront-proxy/blob/3dd1fa11711a04de2d9d418e2269f0f9fb464f36/proxy/src/main/java/com/wavefront/agent/listeners/tracing/ZipkinPortUnificationHandler.java#L254-L266
+    if (span.kind() != null) {
+      String kind = span.kind().toString().toLowerCase();
+      tags.add(Pair.of("span.kind", kind));
+      if (wavefrontConsumer.hasAnnotations) {
+        tags.add(Pair.of("_spanSecondaryId", kind));
+      }
+    }
+
+    // https://github.com/wavefrontHQ/wavefront-proxy/blob/3dd1fa11711a04de2d9d418e2269f0f9fb464f36/proxy/src/main/java/com/wavefront/agent/listeners/tracing/ZipkinPortUnificationHandler.java#L329-L332
+    if (wavefrontConsumer.hasAnnotations) {
+      tags.add(Pair.of(SPAN_LOG_KEY, "true"));
+    }
+
+    // https://github.com/wavefrontHQ/wavefront-proxy/blob/3dd1fa11711a04de2d9d418e2269f0f9fb464f36/proxy/src/main/java/com/wavefront/agent/listeners/tracing/ZipkinPortUnificationHandler.java#L324-L327
+    if (span.localIp() != null) {
+      tags.add(Pair.of("ipv4", span.localIp())); // NOTE: this could be IPv6!!
+    }
+
+    try {
+      wavefrontSender.sendSpan(name, start, duration, source, traceId, spanId,
+          parents, followsFrom, tags, spanLogs);
+    } catch (IOException | RuntimeException t) {
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("error sending span " + context, t);
+      }
+    }
+    return true; // regardless of error, other handlers should run
+  }
+
+  static class WavefrontConsumer
+      implements AnnotationConsumer<List<SpanLog>>, TagConsumer<List<Pair<String, String>>> {
+    final Set<String> defaultTagKeys;
+    boolean debug, hasAnnotations;
+
+    WavefrontConsumer(Set<String> defaultTagKeys) {
+      this.defaultTagKeys = defaultTagKeys;
+    }
+
+    @Override public void accept(List<SpanLog> target, long timestamp, String value) {
+      hasAnnotations = true;
+      target.add(new SpanLog(timestamp, Collections.singletonMap("annotation", value)));
+    }
+
+    @Override public void accept(List<Pair<String, String>> target, String key, String value) {
+      if (value.isEmpty()) return;
+      String lcKey = key.toLowerCase(Locale.ROOT);
+      if (defaultTagKeys.contains(lcKey)) return;
+      if (lcKey.equals(DEBUG_TAG_KEY)) {
+        debug = true; // This tag is set out-of-band
+        return;
+      }
+      if (lcKey.equals(ERROR_TAG_KEY)) {
+        value = "true"; // Ignore the original error value
+      }
+      target.add(Pair.of(key, value));
+    }
+  }
+}

--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontTracingConfiguration.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontTracingConfiguration.java
@@ -33,7 +33,8 @@ import static com.wavefront.sdk.common.Constants.SHARD_TAG_KEY;
  */
 @ConditionalOnClass(TracingCustomizer.class)
 @AutoConfigureBefore(TraceAutoConfiguration.class)
-@Import(SamplerAutoConfiguration.class) // TODO: investigate
+// This import is safe, but can be removed in Sleuth 2.2.3 or 3.0.0.M2
+@Import(SamplerAutoConfiguration.class)
 @ConditionalOnProperty(value = "wavefront.tracing.enabled", matchIfMissing = true)
 class WavefrontTracingConfiguration {
   static final String BEAN_NAME = "wavefrontTracingCustomizer";

--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontTracingConfiguration.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontTracingConfiguration.java
@@ -1,36 +1,85 @@
 package com.wavefront.spring.autoconfigure;
 
-import com.wavefront.opentracing.WavefrontTracer;
-import com.wavefront.opentracing.reporting.Reporter;
-import com.wavefront.opentracing.reporting.WavefrontSpanReporter;
-import com.wavefront.sdk.common.WavefrontSender;
+import brave.TracingCustomizer;
+import com.wavefront.sdk.common.Pair;
 import com.wavefront.sdk.common.application.ApplicationTags;
+import com.wavefront.sdk.entities.tracing.WavefrontTracingSpanSender;
 import io.micrometer.wavefront.WavefrontConfig;
-import io.opentracing.Tracer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.sleuth.LocalServiceName;
+import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
+import org.springframework.cloud.sleuth.sampler.SamplerAutoConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+import static com.wavefront.sdk.common.Constants.APPLICATION_TAG_KEY;
+import static com.wavefront.sdk.common.Constants.CLUSTER_TAG_KEY;
+import static com.wavefront.sdk.common.Constants.NULL_TAG_VAL;
+import static com.wavefront.sdk.common.Constants.SERVICE_TAG_KEY;
+import static com.wavefront.sdk.common.Constants.SHARD_TAG_KEY;
 
 /**
  * Configuration for Wavefront tracing.
  *
  * @author Stephane Nicoll
  */
-@ConditionalOnClass({ Reporter.class, Tracer.class })
+@ConditionalOnClass(TracingCustomizer.class)
+@AutoConfigureBefore(TraceAutoConfiguration.class)
+@Import(SamplerAutoConfiguration.class) // TODO: investigate
 @ConditionalOnProperty(value = "wavefront.tracing.enabled", matchIfMissing = true)
 class WavefrontTracingConfiguration {
+  static final String BEAN_NAME = "wavefrontTracingCustomizer";
+  /**
+   * Wavefront use a combination of null and non-values in defaults. Some non-values are not
+   * defined by constants. This constant helps reduce drift in non-value comparison.
+   */
+  static final String DEFAULT_SERVICE = new WavefrontProperties().getApplication().getService();
 
-  @Bean
-  @ConditionalOnMissingBean(Tracer.class)
-  @ConditionalOnBean(WavefrontSender.class)
-  WavefrontTracer wavefrontTracer(WavefrontSender wavefrontSender, ApplicationTags applicationTags,
-      WavefrontConfig wavefrontConfig) {
-    Reporter spanReporter = new WavefrontSpanReporter.Builder().withSource(wavefrontConfig.source())
-        .build(wavefrontSender);
-    return new WavefrontTracer.Builder(spanReporter, applicationTags).build();
+  @Bean(BEAN_NAME)
+  @ConditionalOnMissingBean(name = BEAN_NAME)
+  @ConditionalOnBean(WavefrontTracingSpanSender.class)
+  TracingCustomizer wavefrontTracingCustomizer(
+      WavefrontTracingSpanSender wavefrontSender,
+      ApplicationTags applicationTags,
+      WavefrontConfig wavefrontConfig,
+      @LocalServiceName String serviceName
+  ) {
+    WavefrontSpanHandler spanHandler = new WavefrontSpanHandler(
+        wavefrontSender,
+        wavefrontConfig.source(),
+        createDefaultTags(applicationTags, serviceName)
+    );
+
+    return t -> t.traceId128Bit(true).supportsJoin(false).addFinishedSpanHandler(spanHandler);
   }
 
+  // https://github.com/wavefrontHQ/wavefront-opentracing-sdk-java/blob/f1f08d8daf7b692b9b61dcd5bc24ca6befa8e710/src/main/java/com/wavefront/opentracing/WavefrontTracer.java#L275-L280
+  static List<Pair<String, String>> createDefaultTags(ApplicationTags applicationTags,
+      String serviceName) {
+    List<Pair<String, String>> result = new ArrayList<>();
+    result.add(Pair.of(APPLICATION_TAG_KEY, applicationTags.getApplication()));
+    // Prefer the user's service name unless they overwrote it with the wavefront property
+    // https://github.com/wavefrontHQ/wavefront-proxy/blob/3dd1fa11711a04de2d9d418e2269f0f9fb464f36/proxy/src/main/java/com/wavefront/agent/listeners/tracing/ZipkinPortUnificationHandler.java#L263-L266
+    if (!Objects.equals(applicationTags.getService(), DEFAULT_SERVICE) ) {
+      result.add(Pair.of(SERVICE_TAG_KEY, applicationTags.getService()));
+    } else {
+      result.add(Pair.of(SERVICE_TAG_KEY, serviceName));
+    }
+    result.add(Pair.of(CLUSTER_TAG_KEY,
+        applicationTags.getCluster() == null ? NULL_TAG_VAL : applicationTags.getCluster()));
+    result.add(Pair.of(SHARD_TAG_KEY,
+        applicationTags.getShard() == null ? NULL_TAG_VAL : applicationTags.getShard()));
+    if (applicationTags.getCustomTags() != null) {
+      applicationTags.getCustomTags().forEach((k, v) -> result.add(Pair.of(k, v)));
+    }
+    return result;
+  }
 }

--- a/wavefront-spring-boot/src/test/java/com/wavefront/spring/autoconfigure/IntegratedTracingTests.java
+++ b/wavefront-spring-boot/src/test/java/com/wavefront/spring/autoconfigure/IntegratedTracingTests.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.wavefront.spring.autoconfigure;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.LinkedBlockingDeque;
+
+import com.wavefront.sdk.common.Pair;
+import com.wavefront.sdk.common.annotation.Nullable;
+import com.wavefront.sdk.entities.tracing.SpanLog;
+import com.wavefront.sdk.entities.tracing.WavefrontTracingSpanSender;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.server.HandlerFunction;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = IntegratedTracingTests.Config.class,
+    properties = {
+        "spring.application.name=IntegratedTracingTests",
+        // Adrian thinks this one should be default in spring
+        "wavefront.application.name=${spring.application.name}",
+        "spring.zipkin.service.name=test_service"
+    }
+)
+public class IntegratedTracingTests {
+  @Autowired BlockingDeque<SpanRecord> spanRecordQueue;
+  @LocalServerPort int port;
+
+  @Test void sendsToWavefront() throws Exception {
+    WebClient.create().get()
+        .uri("http://localhost:" + port + "/api/fn/10")
+        .header("b3", "0000000000000001-0000000000000003-1-0000000000000002")
+        .exchange().block();
+
+    SpanRecord spanRecord = spanRecordQueue.take();
+    assertThat(spanRecord.traceId)
+        .hasToString("00000000-0000-0000-0000-000000000001");
+    assertThat(spanRecord.parents).extracting(UUID::toString)
+        .containsExactly("00000000-0000-0000-0000-000000000003");
+    assertThat(spanRecord.followsFrom).isNull();
+    // This tests that RPC spans do not share the same span ID
+    assertThat(spanRecord.spanId.toString())
+        .isNotEqualTo("00000000-0000-0000-0000-000000000003")
+        .matches("^[0-9a-f]{8}\\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\\b[0-9a-f]{12}$");
+    assertThat(spanRecord.name)
+        .isEqualTo("GET /api/fn/{id}");
+
+    // spot check the unit is valid (millis not micros)
+    long currentTime = System.currentTimeMillis();
+    assertThat(spanRecord.startMillis)
+        .isGreaterThan(currentTime - 5000)
+        .isLessThan(currentTime);
+    // Less than a millis should round up to 1, but the test could take longer than 1ms
+    assertThat(spanRecord.durationMillis).isPositive();
+
+    assertThat(spanRecord.tags).containsExactly(
+        Pair.of("application", "IntegratedTracingTests"),
+        Pair.of("service", "test_service"),
+        Pair.of("cluster", "none"),
+        Pair.of("shard", "none"),
+        Pair.of("http.method", "GET"),
+        Pair.of("http.path", "/api/fn/10"),
+        Pair.of("mvc.controller.class", "Controller"),
+        Pair.of("span.kind", "server")
+    );
+  }
+
+  static final class Controller implements HandlerFunction<ServerResponse> {
+    @Override public Mono<ServerResponse> handle(ServerRequest serverRequest) {
+      return ServerResponse.ok()
+          .bodyValue(serverRequest.pathVariable("id"));
+    }
+  }
+
+  @Configuration
+  @EnableAutoConfiguration
+  static class Config {
+    @Bean WebClient webClient() {
+      return WebClient.create();
+    }
+
+    @Bean RouterFunction<ServerResponse> route() {
+      return RouterFunctions.route()
+          .GET("/api/fn/{id}", new Controller())
+          .build();
+    }
+
+    @Bean BlockingDeque<SpanRecord> spanRecordQueue() {
+      return new LinkedBlockingDeque<>();
+    }
+
+    @Bean @Primary
+    WavefrontTracingSpanSender wavefrontTracingSpanSender(BlockingDeque<SpanRecord> queue) {
+      return (name, startMillis, durationMillis, source, traceId, spanId, parents, followsFrom, tags, spanLogs) ->
+          queue.add(new SpanRecord(name, startMillis, durationMillis, source, traceId, spanId,
+              parents, followsFrom, tags, spanLogs));
+    }
+  }
+
+  static final class SpanRecord {
+    final String name;
+    final long startMillis;
+    final long durationMillis;
+    @Nullable final String source;
+    final UUID traceId;
+    final UUID spanId;
+    @Nullable final List<UUID> parents;
+    @Nullable final List<UUID> followsFrom;
+    @Nullable final List<Pair<String, String>> tags;
+    @Nullable final List<SpanLog> spanLogs;
+
+    SpanRecord(
+        String name,
+        long startMillis,
+        long durationMillis,
+        @Nullable String source,
+        UUID traceId, UUID spanId,
+        @Nullable List<UUID> parents,
+        @Nullable List<UUID> followsFrom,
+        @Nullable List<Pair<String, String>> tags,
+        @Nullable List<SpanLog> spanLogs
+    ) {
+      this.name = name;
+      this.startMillis = startMillis;
+      this.durationMillis = durationMillis;
+      this.source = source;
+      this.traceId = traceId;
+      this.spanId = spanId;
+      this.parents = parents;
+      this.followsFrom = followsFrom;
+      this.tags = tags;
+      this.spanLogs = spanLogs;
+    }
+  }
+}


### PR DESCRIPTION
This covers the data format from https://github.com/wavefrontHQ/wavefront-proxy/blob/3dd1fa11711a04de2d9d418e2269f0f9fb464f36/proxy/src/main/java/com/wavefront/agent/listeners/tracing/ZipkinPortUnificationHandler.java

This integrates with Sleuth 2.2, but doesn't use any new apis (would work even in Spring XML 2.5)

I've not been successful getting an account working with wavefront, it kicked out my vmware email and my attempt to register from my google account resulted in no email link (not trash etc)

Would appreciate someone with access verifying this as I noticed this project has no CI to actually integration test with the wavefront service, so hard to tell even before worked.