### PR TITLE
Do not run in the bootstrap context phase

### DIFF
--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/account/AccountManagementEnvironmentPostProcessor.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/account/AccountManagementEnvironmentPostProcessor.java
@@ -53,6 +53,10 @@ class AccountManagementEnvironmentPostProcessor
 
   @Override
   public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
+    if (environment.getPropertySources().contains("bootstrap")) {
+      // Do not run in the bootstrap phase as the user configuration is not available yet
+      return;
+    }
     application.addListeners(this);
     if (!isApiTokenRequired(environment)) {
       return;


### PR DESCRIPTION
When Spring Cloud is added to an application, it may use a bootstrap
phase that is used to fetch user configuration. Unfortunately, regular
callbacks such as the registered EnvironmentPostProcessor are called,
see https://github.com/spring-cloud/spring-cloud-commons/issues/737.

Running the account management check in the bootstrap phase is useless
as we have to check if the user has configured an account before
provisioning one. This commit adds a an extra check to not run in the
bootstrap phase. At the moment, this is determined by the presence of
a property source named "bootstrap" that the bootstrap context adds.