### PR TITLE
Emit Span RED metrics for Sleuth

### DIFF
--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/HeartbeatMetricKey.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/HeartbeatMetricKey.java
@@ -5,85 +5,85 @@ import java.util.Map;
 import javax.annotation.Nonnull;
 
 /**
- * Composition class that makes up the heartbeat metric.
- * TODO: Move to Wavefront SDK Java (https://github.com/wavefrontHQ/wavefront-sdk-java)
+ * Composition class that makes up the heartbeat metric. TODO: Move to Wavefront SDK Java
+ * (https://github.com/wavefrontHQ/wavefront-sdk-java)
  *
  * @author Hao Song (songhao@vmware.com).
  */
 public class HeartbeatMetricKey {
-    @Nonnull
-    private final String application;
-    @Nonnull
-    private final String service;
-    @Nonnull
-    private final String cluster;
-    @Nonnull
-    private final String shard;
-    @Nonnull
-    private final String source;
-    @Nonnull
-    private final Map<String, String> customTags;
+  @Nonnull
+  private final String application;
+  @Nonnull
+  private final String service;
+  @Nonnull
+  private final String cluster;
+  @Nonnull
+  private final String shard;
+  @Nonnull
+  private final String source;
+  @Nonnull
+  private final Map<String, String> customTags;
 
-    HeartbeatMetricKey(@Nonnull String application, @Nonnull String service,
-                       @Nonnull String cluster, @Nonnull String shard,
-                       @Nonnull String source, @Nonnull Map<String, String> customTags) {
-        this.application = application;
-        this.service = service;
-        this.cluster = cluster;
-        this.shard = shard;
-        this.source = source;
-        this.customTags = customTags;
+  HeartbeatMetricKey(@Nonnull String application, @Nonnull String service,
+                     @Nonnull String cluster, @Nonnull String shard,
+                     @Nonnull String source, @Nonnull Map<String, String> customTags) {
+    this.application = application;
+    this.service = service;
+    this.cluster = cluster;
+    this.shard = shard;
+    this.source = source;
+    this.customTags = customTags;
+  }
+
+  @Nonnull
+  String getApplication() {
+    return application;
+  }
+
+  @Nonnull
+  String getService() {
+    return service;
+  }
+
+  @Nonnull
+  String getCluster() {
+    return cluster;
+  }
+
+  @Nonnull
+  String getShard() {
+    return shard;
+  }
+
+  @Nonnull
+  String getSource() {
+    return source;
+  }
+
+  @Nonnull
+  Map<String, String> getCustomTags() {
+    return customTags;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
     }
 
-    @Nonnull
-    String getApplication() {
-        return application;
+    if (o == null || getClass() != o.getClass()) {
+      return false;
     }
 
-    @Nonnull
-    String getService() {
-        return service;
-    }
+    HeartbeatMetricKey other = (HeartbeatMetricKey) o;
+    return application.equals(other.application) && service.equals(other.service) &&
+        cluster.equals(other.cluster) && shard.equals(other.shard) &&
+        source.equals(other.source) && customTags.equals(other.customTags);
+  }
 
-    @Nonnull
-    String getCluster() {
-        return cluster;
-    }
-
-    @Nonnull
-    String getShard() {
-        return shard;
-    }
-
-    @Nonnull
-    String getSource() {
-        return source;
-    }
-
-    @Nonnull
-    Map<String, String> getCustomTags() {
-        return customTags;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        HeartbeatMetricKey other = (HeartbeatMetricKey) o;
-        return application.equals(other.application) && service.equals(other.service) &&
-            cluster.equals(other.cluster) && shard.equals(other.shard) &&
-            source.equals(other.source) && customTags.equals(other.customTags);
-    }
-
-    @Override
-    public int hashCode() {
-        return application.hashCode() + 31 * service.hashCode() + 31 * cluster.hashCode() +
-            31 * shard.hashCode() + 31 * source.hashCode() + 31 * customTags.hashCode();
-    }
+  @Override
+  public int hashCode() {
+    return application.hashCode() + 31 * service.hashCode() + 31 * cluster.hashCode() +
+        31 * shard.hashCode() + 31 * source.hashCode() + 31 * customTags.hashCode();
+  }
 }

--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/HeartbeatMetricKey.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/HeartbeatMetricKey.java
@@ -5,8 +5,9 @@ import java.util.Map;
 import javax.annotation.Nonnull;
 
 /**
- * Composition class that makes up the heartbeat metric. TODO: Move to Wavefront SDK Java
- * (https://github.com/wavefrontHQ/wavefront-sdk-java)
+ * Composition class that makes up the heartbeat metric.
+ * https://github.com/wavefrontHQ/wavefront-proxy/blob/master/proxy/src/main/java/com/wavefront/agent/listeners/tracing/HeartbeatMetricKey.java
+ * TODO: Move to Wavefront SDK Java (https://github.com/wavefrontHQ/wavefront-sdk-java)
  *
  * @author Hao Song (songhao@vmware.com).
  */

--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/HeartbeatMetricKey.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/HeartbeatMetricKey.java
@@ -1,0 +1,88 @@
+package com.wavefront.spring.autoconfigure;
+
+import java.util.Map;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Composition class that makes up the heartbeat metric.
+ *
+ * @author Hao Song (songhao@vmware.com).
+ */
+public class HeartbeatMetricKey {
+    @Nonnull
+    private final String application;
+    @Nonnull
+    private final String service;
+    @Nonnull
+    private final String cluster;
+    @Nonnull
+    private final String shard;
+    @Nonnull
+    private final String source;
+    @Nonnull
+    private final Map<String, String> customTags;
+
+    HeartbeatMetricKey(@Nonnull String application, @Nonnull String service,
+                       @Nonnull String cluster, @Nonnull String shard,
+                       @Nonnull String source, @Nonnull Map<String, String> customTags) {
+        this.application = application;
+        this.service = service;
+        this.cluster = cluster;
+        this.shard = shard;
+        this.source = source;
+        this.customTags = customTags;
+    }
+
+    @Nonnull
+    String getApplication() {
+        return application;
+    }
+
+    @Nonnull
+    String getService() {
+        return service;
+    }
+
+    @Nonnull
+    String getCluster() {
+        return cluster;
+    }
+
+    @Nonnull
+    String getShard() {
+        return shard;
+    }
+
+    @Nonnull
+    String getSource() {
+        return source;
+    }
+
+    @Nonnull
+    Map<String, String> getCustomTags() {
+        return customTags;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        HeartbeatMetricKey other = (HeartbeatMetricKey) o;
+        return application.equals(other.application) && service.equals(other.service) &&
+            cluster.equals(other.cluster) && shard.equals(other.shard) &&
+            source.equals(other.source) && customTags.equals(other.customTags);
+    }
+
+    @Override
+    public int hashCode() {
+        return application.hashCode() + 31 * service.hashCode() + 31 * cluster.hashCode() +
+            31 * shard.hashCode() + 31 * source.hashCode() + 31 * customTags.hashCode();
+    }
+}

--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/HeartbeatMetricKey.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/HeartbeatMetricKey.java
@@ -6,6 +6,7 @@ import javax.annotation.Nonnull;
 
 /**
  * Composition class that makes up the heartbeat metric.
+ * TODO: Move to Wavefront SDK Java (https://github.com/wavefrontHQ/wavefront-sdk-java)
  *
  * @author Hao Song (songhao@vmware.com).
  */

--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/SpanDerivedMetricsUtils.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/SpanDerivedMetricsUtils.java
@@ -26,6 +26,8 @@ import static io.opentracing.tag.Tags.SPAN_KIND;
 
 /**
  * Util methods to generate data (metrics/histograms/heartbeats) from tracing spans
+ * https://github.com/wavefrontHQ/wavefront-proxy/blob/master/proxy/src/main/java/com/wavefront/agent/listeners/tracing/SpanDerivedMetricsUtils.java
+ * TODO: Move to Wavefront Internal Reporter (https://github.com/wavefrontHQ/wavefront-internal-reporter-java)
  *
  * @author Hao Song (songhao@vmware.com).
  */

--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/SpanDerivedMetricsUtils.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/SpanDerivedMetricsUtils.java
@@ -1,0 +1,155 @@
+package com.wavefront.spring.autoconfigure;
+
+import com.wavefront.internal.reporter.WavefrontInternalReporter;
+import com.wavefront.internal_reporter_java.io.dropwizard.metrics5.MetricName;
+import com.wavefront.sdk.common.Pair;
+import com.wavefront.sdk.common.WavefrontSender;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.wavefront.sdk.common.Constants.APPLICATION_TAG_KEY;
+import static com.wavefront.sdk.common.Constants.CLUSTER_TAG_KEY;
+import static com.wavefront.sdk.common.Constants.COMPONENT_TAG_KEY;
+import static com.wavefront.sdk.common.Constants.HEART_BEAT_METRIC;
+import static com.wavefront.sdk.common.Constants.SERVICE_TAG_KEY;
+import static com.wavefront.sdk.common.Constants.SHARD_TAG_KEY;
+import static com.wavefront.sdk.common.Constants.SOURCE_KEY;
+import static com.wavefront.sdk.common.Constants.NULL_TAG_VAL;
+import static com.wavefront.sdk.common.Utils.sanitizeWithoutQuotes;
+
+import static io.opentracing.tag.Tags.SPAN_KIND;
+
+/**
+ * Util methods to generate data (metrics/histograms/heartbeats) from tracing spans
+ *
+ * @author Hao Song (songhao@vmware.com).
+ */
+public class SpanDerivedMetricsUtils {
+
+    public final static String TRACING_DERIVED_PREFIX = "tracing.derived";
+    private final static String INVOCATION_SUFFIX = ".invocation";
+    private final static String ERROR_SUFFIX = ".error";
+    private final static String DURATION_SUFFIX = ".duration.micros";
+    private final static String TOTAL_TIME_SUFFIX = ".total_time.millis";
+    private final static String OPERATION_NAME_TAG = "operationName";
+
+    /**
+     * Report generated metrics and histograms from the wavefront tracing span.
+     *
+     * @param operationName               span operation name.
+     * @param application                 name of the application.
+     * @param service                     name of the service.
+     * @param cluster                     name of the cluster.
+     * @param shard                       name of the shard.
+     * @param source                      reporting source.
+     * @param componentTagValue           component tag value.
+     * @param isError                     indicates if the span is erroneous.
+     * @param spanDurationMicros          Original span duration (both Zipkin and Jaeger support
+     *                                    micros duration).
+     * @param traceDerivedCustomTagKeys   custom tags added to derived RED metrics.
+     * @param spanAnnotations             span tags.
+     *
+     * @return HeartbeatMetricKey so that it is added to discovered keys.
+     */
+    static HeartbeatMetricKey reportWavefrontGeneratedData(
+        WavefrontInternalReporter wfInternalReporter, String operationName, String application,
+        String service, String cluster, String shard, String source, String componentTagValue,
+        boolean isError, long spanDurationMicros, Set<String> traceDerivedCustomTagKeys,
+        List<Pair<String, String>> spanAnnotations) {
+        /*
+         * 1) Can only propagate mandatory application/service and optional cluster/shard tags.
+         * 2) Cannot convert ApplicationTags.customTags unfortunately as those are not well-known.
+         * 3) Both Jaeger and Zipkin support error=true tag for erroneous spans
+         */
+
+        Map<String, String> pointTags = new HashMap<String, String>() {{
+            put(APPLICATION_TAG_KEY, application);
+            put(SERVICE_TAG_KEY, service);
+            put(CLUSTER_TAG_KEY, cluster);
+            put(SHARD_TAG_KEY, shard);
+            put(OPERATION_NAME_TAG, operationName);
+            put(COMPONENT_TAG_KEY, componentTagValue);
+            put(SOURCE_KEY, source);
+        }};
+
+        /*
+         * Use a separate customTagsMap and keep it separate from individual point tags, since
+         * we do not propagate the original span component.
+         */
+        Map<String, String> customTags = new HashMap<>();
+        if (traceDerivedCustomTagKeys.size() > 0) {
+            spanAnnotations.forEach((annotation) -> {
+                if (traceDerivedCustomTagKeys.contains(annotation._1)) {
+                    pointTags.put(annotation._1, annotation._2);
+                    customTags.put(annotation._1, annotation._2);
+                }
+            });
+        }
+
+        // tracing.derived.<application>.<service>.<operation>.invocation.count
+        wfInternalReporter.newDeltaCounter(new MetricName(sanitizeWithoutQuotes(application +
+            "." + service + "." + operationName + INVOCATION_SUFFIX), pointTags)).inc();
+
+        if (isError) {
+            // tracing.derived.<application>.<service>.<operation>.error.count
+            wfInternalReporter.newDeltaCounter(new MetricName(sanitizeWithoutQuotes(application +
+                "." + service + "." + operationName + ERROR_SUFFIX), pointTags)).inc();
+        }
+
+        // tracing.derived.<application>.<service>.<operation>.duration.micros.m
+        if (isError) {
+            Map<String, String> errorPointTags = new HashMap<>(pointTags);
+            errorPointTags.put("error", "true");
+            wfInternalReporter.newWavefrontHistogram(new MetricName(sanitizeWithoutQuotes(application +
+                "." + service + "." + operationName + DURATION_SUFFIX), errorPointTags)).
+                update(spanDurationMicros);
+        } else {
+            wfInternalReporter.newWavefrontHistogram(new MetricName(sanitizeWithoutQuotes(application +
+                "." + service + "." + operationName + DURATION_SUFFIX), pointTags)).
+                update(spanDurationMicros);
+        }
+
+        // tracing.derived.<application>.<service>.<operation>.total_time.millis.count
+        wfInternalReporter.newDeltaCounter(new MetricName(sanitizeWithoutQuotes(application +
+            "." + service + "." + operationName + TOTAL_TIME_SUFFIX), pointTags)).
+            inc(spanDurationMicros / 1000);
+        return new HeartbeatMetricKey(application, service, cluster, shard, source, customTags);
+    }
+
+    /**
+     * Report discovered heartbeats to Wavefront.
+     *
+     * @param wavefrontSender             Wavefront sender via proxy.
+     * @param discoveredHeartbeatMetrics  Discovered heartbeats.
+     */
+    static void reportHeartbeats(String component,
+                                 WavefrontSender wavefrontSender,
+                                 Map<HeartbeatMetricKey, Boolean> discoveredHeartbeatMetrics) throws IOException {
+        if (wavefrontSender == null) {
+            // should never happen
+            return;
+        }
+        Iterator<HeartbeatMetricKey> iter = discoveredHeartbeatMetrics.keySet().iterator();
+        while (iter.hasNext()) {
+            HeartbeatMetricKey key = iter.next();
+            Map<String, String> tags = new HashMap<String, String>() {{
+                put(APPLICATION_TAG_KEY, key.getApplication());
+                put(SERVICE_TAG_KEY, key.getService());
+                put(CLUSTER_TAG_KEY, key.getCluster());
+                put(SHARD_TAG_KEY, key.getShard());
+                put(COMPONENT_TAG_KEY, component);
+                putAll(key.getCustomTags());
+            }};
+            tags.putIfAbsent(SPAN_KIND.getKey(), NULL_TAG_VAL);
+            wavefrontSender.sendMetric(HEART_BEAT_METRIC, 1.0, System.currentTimeMillis(),
+                key.getSource(), tags);
+            // remove from discovered list so that it is only reported on subsequent discovery
+            discoveredHeartbeatMetrics.remove(key);
+        }
+    }
+}

--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/SpanDerivedMetricsUtils.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/SpanDerivedMetricsUtils.java
@@ -31,125 +31,124 @@ import static io.opentracing.tag.Tags.SPAN_KIND;
  */
 public class SpanDerivedMetricsUtils {
 
-    public final static String TRACING_DERIVED_PREFIX = "tracing.derived";
-    private final static String INVOCATION_SUFFIX = ".invocation";
-    private final static String ERROR_SUFFIX = ".error";
-    private final static String DURATION_SUFFIX = ".duration.micros";
-    private final static String TOTAL_TIME_SUFFIX = ".total_time.millis";
-    private final static String OPERATION_NAME_TAG = "operationName";
+  public final static String TRACING_DERIVED_PREFIX = "tracing.derived";
+  private final static String INVOCATION_SUFFIX = ".invocation";
+  private final static String ERROR_SUFFIX = ".error";
+  private final static String DURATION_SUFFIX = ".duration.micros";
+  private final static String TOTAL_TIME_SUFFIX = ".total_time.millis";
+  private final static String OPERATION_NAME_TAG = "operationName";
 
-    /**
-     * Report generated metrics and histograms from the wavefront tracing span.
-     *
-     * @param operationName               span operation name.
-     * @param application                 name of the application.
-     * @param service                     name of the service.
-     * @param cluster                     name of the cluster.
-     * @param shard                       name of the shard.
-     * @param source                      reporting source.
-     * @param componentTagValue           component tag value.
-     * @param isError                     indicates if the span is erroneous.
-     * @param spanDurationMicros          Original span duration (both Zipkin and Jaeger support
-     *                                    micros duration).
-     * @param traceDerivedCustomTagKeys   custom tags added to derived RED metrics.
-     * @param spanAnnotations             span tags.
-     *
-     * @return HeartbeatMetricKey so that it is added to discovered keys.
+  /**
+   * Report generated metrics and histograms from the wavefront tracing span.
+   *
+   * @param operationName             span operation name.
+   * @param application               name of the application.
+   * @param service                   name of the service.
+   * @param cluster                   name of the cluster.
+   * @param shard                     name of the shard.
+   * @param source                    reporting source.
+   * @param componentTagValue         component tag value.
+   * @param isError                   indicates if the span is erroneous.
+   * @param spanDurationMicros        Original span duration (both Zipkin and Jaeger support micros
+   *                                  duration).
+   * @param traceDerivedCustomTagKeys custom tags added to derived RED metrics.
+   * @param spanAnnotations           span tags.
+   * @return HeartbeatMetricKey so that it is added to discovered keys.
+   */
+  static HeartbeatMetricKey reportWavefrontGeneratedData(
+      WavefrontInternalReporter wfInternalReporter, String operationName, String application,
+      String service, String cluster, String shard, String source, String componentTagValue,
+      boolean isError, long spanDurationMicros, Set<String> traceDerivedCustomTagKeys,
+      List<Pair<String, String>> spanAnnotations) {
+    /*
+     * 1) Can only propagate mandatory application/service and optional cluster/shard tags.
+     * 2) Cannot convert ApplicationTags.customTags unfortunately as those are not well-known.
+     * 3) Both Jaeger and Zipkin support error=true tag for erroneous spans
      */
-    static HeartbeatMetricKey reportWavefrontGeneratedData(
-        WavefrontInternalReporter wfInternalReporter, String operationName, String application,
-        String service, String cluster, String shard, String source, String componentTagValue,
-        boolean isError, long spanDurationMicros, Set<String> traceDerivedCustomTagKeys,
-        List<Pair<String, String>> spanAnnotations) {
-        /*
-         * 1) Can only propagate mandatory application/service and optional cluster/shard tags.
-         * 2) Cannot convert ApplicationTags.customTags unfortunately as those are not well-known.
-         * 3) Both Jaeger and Zipkin support error=true tag for erroneous spans
-         */
 
-        Map<String, String> pointTags = new HashMap<String, String>() {{
-            put(APPLICATION_TAG_KEY, application);
-            put(SERVICE_TAG_KEY, service);
-            put(CLUSTER_TAG_KEY, cluster);
-            put(SHARD_TAG_KEY, shard);
-            put(OPERATION_NAME_TAG, operationName);
-            put(COMPONENT_TAG_KEY, componentTagValue);
-            put(SOURCE_KEY, source);
-        }};
+    Map<String, String> pointTags = new HashMap<String, String>() {{
+      put(APPLICATION_TAG_KEY, application);
+      put(SERVICE_TAG_KEY, service);
+      put(CLUSTER_TAG_KEY, cluster);
+      put(SHARD_TAG_KEY, shard);
+      put(OPERATION_NAME_TAG, operationName);
+      put(COMPONENT_TAG_KEY, componentTagValue);
+      put(SOURCE_KEY, source);
+    }};
 
-        /*
-         * Use a separate customTagsMap and keep it separate from individual point tags, since
-         * we do not propagate the original span component.
-         */
-        Map<String, String> customTags = new HashMap<>();
-        if (traceDerivedCustomTagKeys.size() > 0) {
-            spanAnnotations.forEach((annotation) -> {
-                if (traceDerivedCustomTagKeys.contains(annotation._1)) {
-                    pointTags.put(annotation._1, annotation._2);
-                    customTags.put(annotation._1, annotation._2);
-                }
-            });
+    /*
+     * Use a separate customTagsMap and keep it separate from individual point tags, since
+     * we do not propagate the original span component.
+     */
+    Map<String, String> customTags = new HashMap<>();
+    if (traceDerivedCustomTagKeys.size() > 0) {
+      spanAnnotations.forEach((annotation) -> {
+        if (traceDerivedCustomTagKeys.contains(annotation._1)) {
+          pointTags.put(annotation._1, annotation._2);
+          customTags.put(annotation._1, annotation._2);
         }
-
-        // tracing.derived.<application>.<service>.<operation>.invocation.count
-        wfInternalReporter.newDeltaCounter(new MetricName(sanitizeWithoutQuotes(application +
-            "." + service + "." + operationName + INVOCATION_SUFFIX), pointTags)).inc();
-
-        if (isError) {
-            // tracing.derived.<application>.<service>.<operation>.error.count
-            wfInternalReporter.newDeltaCounter(new MetricName(sanitizeWithoutQuotes(application +
-                "." + service + "." + operationName + ERROR_SUFFIX), pointTags)).inc();
-        }
-
-        // tracing.derived.<application>.<service>.<operation>.duration.micros.m
-        if (isError) {
-            Map<String, String> errorPointTags = new HashMap<>(pointTags);
-            errorPointTags.put("error", "true");
-            wfInternalReporter.newWavefrontHistogram(new MetricName(sanitizeWithoutQuotes(application +
-                "." + service + "." + operationName + DURATION_SUFFIX), errorPointTags)).
-                update(spanDurationMicros);
-        } else {
-            wfInternalReporter.newWavefrontHistogram(new MetricName(sanitizeWithoutQuotes(application +
-                "." + service + "." + operationName + DURATION_SUFFIX), pointTags)).
-                update(spanDurationMicros);
-        }
-
-        // tracing.derived.<application>.<service>.<operation>.total_time.millis.count
-        wfInternalReporter.newDeltaCounter(new MetricName(sanitizeWithoutQuotes(application +
-            "." + service + "." + operationName + TOTAL_TIME_SUFFIX), pointTags)).
-            inc(spanDurationMicros / 1000);
-        return new HeartbeatMetricKey(application, service, cluster, shard, source, customTags);
+      });
     }
 
-    /**
-     * Report discovered heartbeats to Wavefront.
-     *
-     * @param wavefrontSender             Wavefront sender via proxy.
-     * @param discoveredHeartbeatMetrics  Discovered heartbeats.
-     */
-    static void reportHeartbeats(String component,
-                                 WavefrontSender wavefrontSender,
-                                 Map<HeartbeatMetricKey, Boolean> discoveredHeartbeatMetrics) throws IOException {
-        if (wavefrontSender == null) {
-            // should never happen
-            return;
-        }
-        Iterator<HeartbeatMetricKey> iter = discoveredHeartbeatMetrics.keySet().iterator();
-        while (iter.hasNext()) {
-            HeartbeatMetricKey key = iter.next();
-            Map<String, String> tags = new HashMap<String, String>() {{
-                put(APPLICATION_TAG_KEY, key.getApplication());
-                put(SERVICE_TAG_KEY, key.getService());
-                put(CLUSTER_TAG_KEY, key.getCluster());
-                put(SHARD_TAG_KEY, key.getShard());
-                put(COMPONENT_TAG_KEY, component);
-                putAll(key.getCustomTags());
-            }};
-            tags.putIfAbsent(SPAN_KIND.getKey(), NULL_TAG_VAL);
-            wavefrontSender.sendMetric(HEART_BEAT_METRIC, 1.0, System.currentTimeMillis(),
-                key.getSource(), tags);
-            // remove from discovered list so that it is only reported on subsequent discovery
-            discoveredHeartbeatMetrics.remove(key);
-        }
+    // tracing.derived.<application>.<service>.<operation>.invocation.count
+    wfInternalReporter.newDeltaCounter(new MetricName(sanitizeWithoutQuotes(application +
+        "." + service + "." + operationName + INVOCATION_SUFFIX), pointTags)).inc();
+
+    if (isError) {
+      // tracing.derived.<application>.<service>.<operation>.error.count
+      wfInternalReporter.newDeltaCounter(new MetricName(sanitizeWithoutQuotes(application +
+          "." + service + "." + operationName + ERROR_SUFFIX), pointTags)).inc();
     }
+
+    // tracing.derived.<application>.<service>.<operation>.duration.micros.m
+    if (isError) {
+      Map<String, String> errorPointTags = new HashMap<>(pointTags);
+      errorPointTags.put("error", "true");
+      wfInternalReporter.newWavefrontHistogram(new MetricName(sanitizeWithoutQuotes(application +
+          "." + service + "." + operationName + DURATION_SUFFIX), errorPointTags)).
+          update(spanDurationMicros);
+    } else {
+      wfInternalReporter.newWavefrontHistogram(new MetricName(sanitizeWithoutQuotes(application +
+          "." + service + "." + operationName + DURATION_SUFFIX), pointTags)).
+          update(spanDurationMicros);
+    }
+
+    // tracing.derived.<application>.<service>.<operation>.total_time.millis.count
+    wfInternalReporter.newDeltaCounter(new MetricName(sanitizeWithoutQuotes(application +
+        "." + service + "." + operationName + TOTAL_TIME_SUFFIX), pointTags)).
+        inc(spanDurationMicros / 1000);
+    return new HeartbeatMetricKey(application, service, cluster, shard, source, customTags);
+  }
+
+  /**
+   * Report discovered heartbeats to Wavefront.
+   *
+   * @param wavefrontSender            Wavefront sender via proxy.
+   * @param discoveredHeartbeatMetrics Discovered heartbeats.
+   */
+  static void reportHeartbeats(String component,
+                               WavefrontSender wavefrontSender,
+                               Map<HeartbeatMetricKey, Boolean> discoveredHeartbeatMetrics) throws IOException {
+    if (wavefrontSender == null) {
+      // should never happen
+      return;
+    }
+    Iterator<HeartbeatMetricKey> iter = discoveredHeartbeatMetrics.keySet().iterator();
+    while (iter.hasNext()) {
+      HeartbeatMetricKey key = iter.next();
+      Map<String, String> tags = new HashMap<String, String>() {{
+        put(APPLICATION_TAG_KEY, key.getApplication());
+        put(SERVICE_TAG_KEY, key.getService());
+        put(CLUSTER_TAG_KEY, key.getCluster());
+        put(SHARD_TAG_KEY, key.getShard());
+        put(COMPONENT_TAG_KEY, component);
+        putAll(key.getCustomTags());
+      }};
+      tags.putIfAbsent(SPAN_KIND.getKey(), NULL_TAG_VAL);
+      wavefrontSender.sendMetric(HEART_BEAT_METRIC, 1.0, System.currentTimeMillis(),
+          key.getSource(), tags);
+      // remove from discovered list so that it is only reported on subsequent discovery
+      discoveredHeartbeatMetrics.remove(key);
+    }
+  }
 }

--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontProperties.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontProperties.java
@@ -2,6 +2,9 @@ package com.wavefront.spring.autoconfigure;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Advanced configuration properties for Wavefront.
  *
@@ -11,6 +14,17 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class WavefrontProperties {
 
   private final Application application = new Application();
+
+  /**
+   * Emit JVM Metrics or not.
+   */
+  private boolean includeJvmMetrics = true;
+
+  /**
+   * Custom Tags for span RED metrics
+   * (https://docs.wavefront.com/tracing_integrations.html#custom-tags-for-red-metrics)
+   */
+  private List<String> traceDerivedCustomTagKeys = new ArrayList<>();
 
   public Application getApplication() {
     return this.application;
@@ -72,4 +86,19 @@ public class WavefrontProperties {
 
   }
 
+  public boolean isIncludeJvmMetrics() {
+    return includeJvmMetrics;
+  }
+
+  public void setIncludeJvmMetrics(boolean includeJvmMetrics) {
+    this.includeJvmMetrics = includeJvmMetrics;
+  }
+
+  public List<String> getTraceDerivedCustomTagKeys() {
+    return traceDerivedCustomTagKeys;
+  }
+
+  public void setIgnoredFilenames(List<String> traceDerivedCustomTagKeys) {
+    this.traceDerivedCustomTagKeys = traceDerivedCustomTagKeys;
+  }
 }

--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontProperties.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontProperties.java
@@ -98,7 +98,7 @@ public class WavefrontProperties {
     return traceDerivedCustomTagKeys;
   }
 
-  public void setIgnoredFilenames(List<String> traceDerivedCustomTagKeys) {
+  public void setTraceDerivedCustomTagKeys(List<String> traceDerivedCustomTagKeys) {
     this.traceDerivedCustomTagKeys = traceDerivedCustomTagKeys;
   }
 }

--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontTracingSleuthConfiguration.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontTracingSleuthConfiguration.java
@@ -59,43 +59,19 @@ class WavefrontTracingSleuthConfiguration {
                                                ApplicationTags applicationTags,
                                                WavefrontConfig wavefrontConfig,
                                                WavefrontProperties wavefrontProperties,
-                                               @LocalServiceName String serviceName) {
-    WavefrontSpanHandler spanHandler = new WavefrontSpanHandler(
+                                               @LocalServiceName String localServiceName) {
+    WavefrontSleuthSpanHandler spanHandler = new WavefrontSleuthSpanHandler(
         // https://github.com/wavefrontHQ/wavefront-opentracing-sdk-java/blob/f1f08d8daf7b692b9b61dcd5bc24ca6befa8e710/src/main/java/com/wavefront/opentracing/reporting/WavefrontSpanReporter.java#L54
         50000, // TODO: maxQueueSize should be a property, ya?
         wavefrontSender,
         meterRegistry,
         wavefrontConfig.source(),
-        createDefaultTags(applicationTags, serviceName),
         applicationTags,
-        wavefrontProperties.isIncludeJvmMetrics(),
-        wavefrontProperties.getTraceDerivedCustomTagKeys()
+        wavefrontProperties,
+        localServiceName
     );
 
     return t -> t.traceId128Bit(true).supportsJoin(false).addFinishedSpanHandler(spanHandler);
-  }
-
-  // https://github.com/wavefrontHQ/wavefront-opentracing-sdk-java/blob/f1f08d8daf7b692b9b61dcd5bc24ca6befa8e710/src/main/java/com/wavefront/opentracing/WavefrontTracer.java#L275-L280
-  static List<Pair<String, String>> createDefaultTags(ApplicationTags applicationTags,
-      String serviceName) {
-    List<Pair<String, String>> result = new ArrayList<>();
-    result.add(Pair.of(APPLICATION_TAG_KEY, applicationTags.getApplication()));
-    // Prefer the user's service name unless they overwrote it with the wavefront property
-    // https://github.com/wavefrontHQ/wavefront-proxy/blob/3dd1fa11711a04de2d9d418e2269f0f9fb464f36/proxy/src/main/java/com/wavefront/agent/listeners/tracing/ZipkinPortUnificationHandler.java#L263-L266
-    if (!Objects.equals(applicationTags.getService(), DEFAULT_SERVICE)) {
-      result.add(Pair.of(SERVICE_TAG_KEY, applicationTags.getService()));
-    }
-    else {
-      result.add(Pair.of(SERVICE_TAG_KEY, serviceName));
-    }
-    result.add(Pair.of(CLUSTER_TAG_KEY,
-        applicationTags.getCluster() == null ? NULL_TAG_VAL : applicationTags.getCluster()));
-    result.add(Pair.of(SHARD_TAG_KEY,
-        applicationTags.getShard() == null ? NULL_TAG_VAL : applicationTags.getShard()));
-    if (applicationTags.getCustomTags() != null) {
-      applicationTags.getCustomTags().forEach((k, v) -> result.add(Pair.of(k, v)));
-    }
-    return result;
   }
 
 }

--- a/wavefront-spring-boot/src/test/java/com/wavefront/spring/autoconfigure/HeartbeatMetricKeyTests.java
+++ b/wavefront-spring-boot/src/test/java/com/wavefront/spring/autoconfigure/HeartbeatMetricKeyTests.java
@@ -1,0 +1,42 @@
+package com.wavefront.spring.autoconfigure;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * Unit tests for {@link HeartbeatMetricKey}.
+ * https://github.com/wavefrontHQ/wavefront-proxy/blob/master/proxy/src/test/java/com/wavefront/agent/listeners/tracing/HeartbeatMetricKeyTest.java
+ * TODO: Move to Wavefront SDK Java (https://github.com/wavefrontHQ/wavefront-sdk-java)
+ *
+ * @author Hao Song (songhao@vmware.com).
+ */
+public class HeartbeatMetricKeyTests {
+
+  @Test
+  public void testEqual() {
+    HeartbeatMetricKey key1 = new HeartbeatMetricKey("app", "service", "cluster", "shard",
+        "source", new HashMap<String, String>() {{
+      put("tenant", "tenant1");
+    }});
+    HeartbeatMetricKey key2 = new HeartbeatMetricKey("app", "service", "cluster", "shard",
+        "source", new HashMap<String, String>() {{
+      put("tenant", "tenant1");
+    }});
+    assertEquals(key1, key2);
+    assertEquals(key1.hashCode(), key2.hashCode());
+  }
+
+  @Test
+  public void testNotEqual() {
+    HeartbeatMetricKey key1 = new HeartbeatMetricKey("app1", "service", "cluster", "shard",
+        "source", new HashMap<>());
+    HeartbeatMetricKey key2 = new HeartbeatMetricKey("app2", "service", "none", "shard",
+        "source", new HashMap<>());
+    assertNotEquals(key1.hashCode(), key2.hashCode());
+    assertNotEquals(key1, key2);
+  }
+}

--- a/wavefront-spring-boot/src/test/java/com/wavefront/spring/autoconfigure/WavefrontAutoConfigurationTests.java
+++ b/wavefront-spring-boot/src/test/java/com/wavefront/spring/autoconfigure/WavefrontAutoConfigurationTests.java
@@ -142,7 +142,7 @@ class WavefrontAutoConfigurationTests {
           assertThat(context.getBean(Tracer.class))
               .extracting("finishedSpanHandler.handlers")
               .asInstanceOf(InstanceOfAssertFactories.array(FinishedSpanHandler[].class))
-              .filteredOn(h -> h instanceof WavefrontSpanHandler)
+              .filteredOn(h -> h instanceof WavefrontSleuthSpanHandler)
               .hasSize(1)
               .extracting("wavefrontSender")
               .contains(sender);

--- a/wavefront-spring-boot/src/test/java/com/wavefront/spring/autoconfigure/WavefrontTracingIntegrationTests.java
+++ b/wavefront-spring-boot/src/test/java/com/wavefront/spring/autoconfigure/WavefrontTracingIntegrationTests.java
@@ -16,14 +16,18 @@
 
 package com.wavefront.spring.autoconfigure;
 
+import java.io.IOException;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.LinkedBlockingDeque;
 
 import com.wavefront.sdk.common.Pair;
+import com.wavefront.sdk.common.WavefrontSender;
+import com.wavefront.sdk.entities.histograms.HistogramGranularity;
 import com.wavefront.sdk.entities.tracing.SpanLog;
-import com.wavefront.sdk.entities.tracing.WavefrontTracingSpanSender;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 
@@ -61,6 +65,9 @@ public class WavefrontTracingIntegrationTests {
 
   @Autowired
   private BlockingDeque<SpanRecord> spanRecordQueue;
+
+  @Autowired
+  private BlockingDeque<String> metricAndHistogramRecordQueue;
 
   @Test
   void sendsToWavefront() throws Exception {
@@ -100,6 +107,10 @@ public class WavefrontTracingIntegrationTests {
         Pair.of("mvc.controller.class", "Controller"),
         Pair.of("span.kind", "server")
     );
+
+    // Wait for 60s to let RED metrics being reported.
+    Thread.sleep(60000);
+    assertThat(metricAndHistogramRecordQueue.isEmpty()).isFalse();
   }
 
   @Configuration
@@ -119,13 +130,64 @@ public class WavefrontTracingIntegrationTests {
     }
 
     @Bean
-    @Primary
-    WavefrontTracingSpanSender wavefrontTracingSpanSender(BlockingDeque<SpanRecord> queue) {
-      return (name, startMillis, durationMillis, source, traceId, spanId, parents, followsFrom, tags, spanLogs) ->
-          queue.add(new SpanRecord(name, startMillis, durationMillis, source, traceId, spanId,
-              parents, followsFrom, tags, spanLogs));
+    BlockingDeque<String> metricAndHistogramRecordQueue() {
+      return new LinkedBlockingDeque<>();
     }
 
+    @Bean
+    @Primary
+    WavefrontSender wavefrontSender(BlockingDeque<SpanRecord> spanRecordQueue,
+                                    BlockingDeque<String> metricAndHistogramRecordQueue) {
+      return new WavefrontSender() {
+        @Override
+        public String getClientId() {
+          return null;
+        }
+
+        @Override
+        public void flush() throws IOException {
+
+        }
+
+        @Override
+        public int getFailureCount() {
+          return 0;
+        }
+
+        @Override
+        public void sendDistribution(String name, List<Pair<Double, Integer>> centroids,
+                                     Set<HistogramGranularity> histogramGranularities,
+                                     Long timestamp, String source, Map<String, String> tags) throws IOException {
+          System.out.println(name);
+          metricAndHistogramRecordQueue.add(name);
+        }
+
+        @Override
+        public void sendMetric(String name, double value, Long timestamp, String source,
+                               Map<String, String> tags) throws IOException {
+          System.out.println(name);
+          metricAndHistogramRecordQueue.add(name);
+        }
+
+        @Override
+        public void sendFormattedMetric(String point) throws IOException {
+
+        }
+
+        @Override
+        public void sendSpan(String name, long startMillis, long durationMillis, String source,
+                             UUID traceId, UUID spanId, List<UUID> parents, List<UUID> followsFrom,
+                             List<Pair<String, String>> tags, List<SpanLog> spanLogs) throws IOException {
+          spanRecordQueue.add(new SpanRecord(name, startMillis, durationMillis, source, traceId,
+              spanId, parents, followsFrom, tags, spanLogs));
+        }
+
+        @Override
+        public void close() throws IOException {
+
+        }
+      };
+    }
   }
 
   static final class Controller implements HandlerFunction<ServerResponse> {

--- a/wavefront-spring-boot/src/test/java/com/wavefront/spring/autoconfigure/WavefrontTracingIntegrationTests.java
+++ b/wavefront-spring-boot/src/test/java/com/wavefront/spring/autoconfigure/WavefrontTracingIntegrationTests.java
@@ -158,14 +158,12 @@ public class WavefrontTracingIntegrationTests {
         public void sendDistribution(String name, List<Pair<Double, Integer>> centroids,
                                      Set<HistogramGranularity> histogramGranularities,
                                      Long timestamp, String source, Map<String, String> tags) throws IOException {
-          System.out.println(name);
           metricAndHistogramRecordQueue.add(name);
         }
 
         @Override
         public void sendMetric(String name, double value, Long timestamp, String source,
                                Map<String, String> tags) throws IOException {
-          System.out.println(name);
           metricAndHistogramRecordQueue.add(name);
         }
 


### PR DESCRIPTION
- Emit Span RED metrics and JVM metrics when using Sleuth
- Add new property `wavefront.include-jvm-metrics` to enable users not emitting JVM metrics (emitting by default)
- Add new property `wavefront.trace-derived-custom-tag-keys` to support custom RED metrics keys