### PR TITLE
Provide single-use login URL even for configured freemium account

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ for more information.
 not support automatic account provisioning, which currently only applies to our free
 cluster. Therefore, make sure you log in to your cluster via the login page or SSO.
 * You have configured an API token explicitly in your `application.properties`. Make sure
-to create a login for your account first.
+to also add `wavefront.freemium-account=true` or create a login for your account.
 
 #### How do I make sure I send data to the same account all the time (across multiple machines and deployments)?
 
@@ -203,6 +203,9 @@ histograms, and traces.
 When you sign-in to your account via the single-use link, click the gear icon on the
 top-right and select Account Management. Next, you can invite yourself by email (a password
 setup link is sent to your email address, and you can use it to set up a password).
+
+If you have set `wavefront.freemium-account=true` in your `application.properties`, make
+sure to remove it so that a single-use login URL is no longer requested on startup.
 
 #### How do I get help?
 

--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/actuate/WavefrontEndpointAutoConfiguration.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/actuate/WavefrontEndpointAutoConfiguration.java
@@ -5,6 +5,7 @@ import java.net.URI;
 import com.wavefront.sdk.common.application.ApplicationTags;
 import com.wavefront.spring.account.AccountManagementClient;
 import com.wavefront.spring.autoconfigure.WavefrontAutoConfiguration;
+import com.wavefront.spring.autoconfigure.WavefrontProperties;
 import io.micrometer.wavefront.WavefrontConfig;
 
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
@@ -16,7 +17,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.web.client.RestTemplateAutoConfiguration;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
-import org.springframework.core.env.Environment;
 import org.springframework.web.client.RestTemplate;
 
 /**
@@ -38,11 +38,10 @@ public class WavefrontEndpointAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
-  WavefrontController wavefrontController(Environment environment,
+  WavefrontController wavefrontController(WavefrontProperties properties,
       AccountManagementClient accountManagementClient, WavefrontConfig wavefrontConfig,
       ApplicationTags applicationTags) {
-    Boolean managedAccount = environment.getProperty("wavefront.managed-account", Boolean.class, false);
-    if (managedAccount) {
+    if (properties.isFreemiumAccount()) {
       return new WavefrontController(new OneTimeDashboardUrlSupplier(
           accountManagementClient, wavefrontConfig, applicationTags));
     }

--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontProperties.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontProperties.java
@@ -13,9 +13,22 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties("wavefront")
 public class WavefrontProperties {
 
+  /**
+   * Whether a freemium account is active, so that a one time login URL is provided.
+   */
+  private boolean freemiumAccount;
+
   private final Application application = new Application();
 
   private final Tracing tracing = new Tracing();
+
+  public boolean isFreemiumAccount() {
+    return this.freemiumAccount;
+  }
+
+  public void setFreemiumAccount(boolean freemiumAccount) {
+    this.freemiumAccount = freemiumAccount;
+  }
 
   public Application getApplication() {
     return this.application;

--- a/wavefront-spring-boot/src/test/java/com/wavefront/spring/actuate/WavefrontEndpointAutoConfigurationTests.java
+++ b/wavefront-spring-boot/src/test/java/com/wavefront/spring/actuate/WavefrontEndpointAutoConfigurationTests.java
@@ -5,12 +5,14 @@ import java.net.URI;
 import com.wavefront.sdk.common.application.ApplicationTags;
 import com.wavefront.spring.account.AccountInfo;
 import com.wavefront.spring.account.AccountManagementClient;
+import com.wavefront.spring.autoconfigure.WavefrontProperties;
 import io.micrometer.wavefront.WavefrontConfig;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.actuate.cache.CachesEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.web.client.RestTemplateAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -32,8 +34,7 @@ class WavefrontEndpointAutoConfigurationTests {
 
   @Test
   void runShouldHaveEndpointBean() {
-    this.contextRunner.withBean(WavefrontConfig.class, () -> mock(WavefrontConfig.class))
-        .withBean(ApplicationTags.class, () -> mock(ApplicationTags.class))
+    this.contextRunner.withUserConfiguration(AccountManagementConfiguration.class)
         .withPropertyValues("management.endpoints.web.exposure.include=wavefront")
         .run((context) -> assertThat(context).hasSingleBean(WavefrontController.class));
   }
@@ -70,9 +71,9 @@ class WavefrontEndpointAutoConfigurationTests {
   }
 
   @Test
-  void runWithManagedAccount() {
+  void runWithFremiumAccount() {
     this.contextRunner.withUserConfiguration(AccountManagementConfiguration.class)
-        .withPropertyValues("wavefront.managed-account=true",
+        .withPropertyValues("wavefront.freemium-account=true",
             "management.endpoints.web.exposure.include=wavefront")
         .run((context) -> {
           assertThat(context).hasSingleBean(WavefrontController.class);
@@ -82,7 +83,7 @@ class WavefrontEndpointAutoConfigurationTests {
   }
 
   @Test
-  void runWithNonManagedAccount() {
+  void runWithNonFreemiumAccount() {
     this.contextRunner.withUserConfiguration(AccountManagementConfiguration.class)
         .withPropertyValues("management.endpoints.web.exposure.include=wavefront")
         .run((context) -> {
@@ -93,6 +94,7 @@ class WavefrontEndpointAutoConfigurationTests {
   }
 
   @Configuration
+  @EnableConfigurationProperties(WavefrontProperties.class)
   static class AccountManagementConfiguration {
 
     private final ApplicationTags applicationTags = mock(ApplicationTags.class);


### PR DESCRIPTION
This commit makes sure a single-use login URL is displayed for freemium
accounts that have been configured explicitly, rather than relying on
the local token file.

Such accounts are identified via the `wavefront.freemium-account`
boolean property. When set, a login URL is requested on startup and the
actuator endpoint requires one on access. This property is set
automatically when an API token is negotiated or read from the local
token file on startup.

Closes gh-38