### PR TITLE
Upgrade to Spring Cloud Sleuth 2.2.3 (Notably Brave 5.12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ project first. Invoke the following command in the root directory:
     ```
     dependencies {
       ...
-      implementation 'org.springframework.cloud:spring-cloud-starter-sleuth:2.2.2.RELEASE'
+      implementation 'org.springframework.cloud:spring-cloud-starter-sleuth:2.2.3.RELEASE'
 
     }
     ```

--- a/wavefront-spring-boot-parent/pom.xml
+++ b/wavefront-spring-boot-parent/pom.xml
@@ -20,7 +20,7 @@
   <properties>
     <java.version>1.8</java.version>
     <spring-boot.version>2.3.0.RELEASE</spring-boot.version>
-    <spring-cloud.version>Hoxton.SR4</spring-cloud.version>
+    <spring-cloud.version>Hoxton.SR5</spring-cloud.version>
   </properties>
 
   <dependencyManagement>

--- a/wavefront-spring-boot/pom.xml
+++ b/wavefront-spring-boot/pom.xml
@@ -44,12 +44,6 @@
       <artifactId>micrometer-registry-wavefront</artifactId>
       <optional>true</optional>
     </dependency>
-    <!-- see https://github.com/spring-cloud/spring-cloud-sleuth/issues/1621 -->
-    <dependency>
-      <groupId>org.aspectj</groupId>
-      <artifactId>aspectjweaver</artifactId>
-      <optional>true</optional>
-    </dependency>
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-sleuth-core</artifactId>

--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontTracingSleuthConfiguration.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontTracingSleuthConfiguration.java
@@ -5,7 +5,6 @@ import com.wavefront.sdk.common.WavefrontSender;
 import com.wavefront.sdk.common.application.ApplicationTags;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.wavefront.WavefrontConfig;
-import org.aspectj.weaver.tools.PointcutPrimitive;
 
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -26,10 +25,8 @@ import org.springframework.context.annotation.Import;
  * @author Stephane Nicoll
  */
 @Configuration(proxyBeanMethods = false)
-@ConditionalOnClass({ SpanNamer.class, TracingCustomizer.class, PointcutPrimitive.class })
+@ConditionalOnClass({ SpanNamer.class, TracingCustomizer.class })
 @AutoConfigureBefore(TraceAutoConfiguration.class)
-// This import is required and can be removed in a future release of Spring Cloud Sleuth
-@Import(SamplerAutoConfiguration.class)
 class WavefrontTracingSleuthConfiguration {
 
   static final String BEAN_NAME = "wavefrontTracingCustomizer";
@@ -60,7 +57,7 @@ class WavefrontTracingSleuthConfiguration {
         localServiceName
     );
 
-    return t -> t.traceId128Bit(true).supportsJoin(false).addFinishedSpanHandler(spanHandler);
+    return t -> t.traceId128Bit(true).supportsJoin(false).addSpanHandler(spanHandler);
   }
 
 }

--- a/wavefront-spring-boot/src/test/java/com/wavefront/spring/autoconfigure/WavefrontAutoConfigurationTests.java
+++ b/wavefront-spring-boot/src/test/java/com/wavefront/spring/autoconfigure/WavefrontAutoConfigurationTests.java
@@ -1,5 +1,6 @@
 package com.wavefront.spring.autoconfigure;
 
+import brave.handler.SpanHandler;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -162,8 +163,10 @@ class WavefrontAutoConfigurationTests {
   }
 
   private WavefrontSleuthSpanHandler extractSpanHandler(Tracer tracer) {
-    FinishedSpanHandler[] handlers = (FinishedSpanHandler[]) ReflectionTestUtils.getField(
-        ReflectionTestUtils.getField(tracer, "finishedSpanHandler"), "handlers");
+    SpanHandler[] handlers = (SpanHandler[]) ReflectionTestUtils.getField(
+        ReflectionTestUtils.getField(
+            ReflectionTestUtils.getField(tracer, "spanHandler"), "delegate"),
+        "handlers");
     return (WavefrontSleuthSpanHandler) handlers[0];
   }
 


### PR DESCRIPTION
This ports to latest Sleuth and I verified also manually.

![Screenshot 2020-05-19 at 11 01 46 AM](https://user-images.githubusercontent.com/64215/82280237-02076b80-99c1-11ea-815b-18124e05f183.png)

For those interested in details:

Brave 5.12 has a cleaner integration for data than before. `SpanHandler`, while
only used for "end" time here, can also do things like aggregate, when "begin"
is implemented.

See https://github.com/openzipkin/brave/blob/master/brave/src/main/java/brave/handler/SpanHandler.java
See https://github.com/openzipkin/brave/blob/master/brave/src/main/java/brave/handler/MutableSpan.java
See https://github.com/openzipkin/brave/tree/master/brave/src/test/java/brave/features/handler
See https://github.com/openzipkin/zipkin-reporter-java/tree/master/brave