### PR TITLE
Disable account negotiation if metric exports is disabled

### DIFF
--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/actuate/WavefrontEndpointAutoConfiguration.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/actuate/WavefrontEndpointAutoConfiguration.java
@@ -41,7 +41,7 @@ public class WavefrontEndpointAutoConfiguration {
   WavefrontController wavefrontController(WavefrontProperties properties,
       AccountManagementClient accountManagementClient, WavefrontConfig wavefrontConfig,
       ApplicationTags applicationTags) {
-    if (properties.isFreemiumAccount()) {
+    if (Boolean.TRUE.equals(properties.getFreemiumAccount())) {
       return new WavefrontController(new OneTimeDashboardUrlSupplier(
           accountManagementClient, wavefrontConfig, applicationTags));
     }

--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/AccountManagementEnvironmentPostProcessor.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/AccountManagementEnvironmentPostProcessor.java
@@ -42,6 +42,8 @@ import org.springframework.util.StringUtils;
 class AccountManagementEnvironmentPostProcessor
     implements EnvironmentPostProcessor, ApplicationListener<SpringApplicationEvent> {
 
+  private static final String ENABLED_PROPERTY = "management.metrics.export.wavefront.enabled";
+
   private static final String API_TOKEN_PROPERTY = "management.metrics.export.wavefront.api-token";
 
   private static final String URI_PROPERTY = "management.metrics.export.wavefront.uri";
@@ -81,11 +83,11 @@ class AccountManagementEnvironmentPostProcessor
       // Do not run in the bootstrap phase as the user configuration is not available yet
       return false;
     }
-    if (!environment.getProperty(FREEMIUM_ACCOUNT_PROPERTY, Boolean.class, true)) {
-      // freemium account explicit disabled
-      return false;
+    Boolean freemiumAccount = environment.getProperty(FREEMIUM_ACCOUNT_PROPERTY, Boolean.class);
+    if (freemiumAccount != null) {
+      return freemiumAccount;
     }
-    return true;
+    return environment.getProperty(ENABLED_PROPERTY, Boolean.class, true);
   }
 
   @Override

--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontProperties.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontProperties.java
@@ -14,19 +14,21 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class WavefrontProperties {
 
   /**
-   * Whether a freemium account has to be configured.
+   * Whether the configured account is a freemium account. Can be enabled explicitly for
+   * user-configured freemium accounts that do not have a user yet. Can be disabled
+   * explicitly to prevent the account negotiation to kick-in.
    */
-  private boolean freemiumAccount;
+  private Boolean freemiumAccount;
 
   private final Application application = new Application();
 
   private final Tracing tracing = new Tracing();
 
-  public boolean isFreemiumAccount() {
+  public Boolean getFreemiumAccount() {
     return this.freemiumAccount;
   }
 
-  public void setFreemiumAccount(boolean freemiumAccount) {
+  public void setFreemiumAccount(Boolean freemiumAccount) {
     this.freemiumAccount = freemiumAccount;
   }
 


### PR DESCRIPTION
This commit makes sure we don't unnecessarily negotiate an account if
metrics export has been disabled. This is also makes sure that
`wavefront.freemium-account` takes precedence if set explicitly. The
role and description of the property has also been polished as part of
this commit

Closes gh-57