### PR TITLE
Disable account management in integration tests

### DIFF
--- a/wavefront-spring-boot-sample/pom.xml
+++ b/wavefront-spring-boot-sample/pom.xml
@@ -31,6 +31,12 @@
       <artifactId>spring-cloud-starter-sleuth</artifactId>
       <scope>runtime</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/AccountManagementEnablementDeducer.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/AccountManagementEnablementDeducer.java
@@ -1,0 +1,53 @@
+package com.wavefront.spring.autoconfigure;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Utility to deduce if the {@link AccountManagementEnvironmentPostProcessor} should be
+ * enabled in the current context.
+ *
+ * @author Madhura Bhave
+ */
+final class AccountManagementEnablementDeducer {
+
+  private static final Set<String> SKIPPED_STACK_ELEMENTS;
+
+  static {
+    Set<String> skipped = new LinkedHashSet<>();
+    skipped.add("org.junit.runners.");
+    skipped.add("org.junit.platform.");
+    skipped.add("org.springframework.boot.test.");
+    skipped.add("cucumber.runtime.");
+    SKIPPED_STACK_ELEMENTS = Collections.unmodifiableSet(skipped);
+  }
+
+  private AccountManagementEnablementDeducer() {
+  }
+
+  /**
+   * Checks if a specific {@link StackTraceElement} in the current thread's stacktrace
+   * should cause account management to be enabled.
+   * @param thread the current thread
+   * @return {@code true} if account management should be enabled
+   */
+  public static boolean shouldEnable(Thread thread) {
+    for (StackTraceElement element : thread.getStackTrace()) {
+      if (isSkippedStackElement(element)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean isSkippedStackElement(StackTraceElement element) {
+    for (String skipped : SKIPPED_STACK_ELEMENTS) {
+      if (element.getClassName().startsWith(skipped)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+}

--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/AccountManagementEnvironmentPostProcessor.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/AccountManagementEnvironmentPostProcessor.java
@@ -87,6 +87,9 @@ class AccountManagementEnvironmentPostProcessor
     if (freemiumAccount != null) {
       return freemiumAccount;
     }
+    if (!shouldEnableAccountManagement(Thread.currentThread())) {
+      return false;
+    }
     return environment.getProperty(ENABLED_PROPERTY, Boolean.class, true);
   }
 
@@ -231,6 +234,10 @@ class AccountManagementEnvironmentPostProcessor
     }
     MapPropertySource wavefrontPropertySource = new MapPropertySource("wavefront", wavefrontSettings);
     environment.getPropertySources().addLast(wavefrontPropertySource);
+  }
+
+  protected boolean shouldEnableAccountManagement(Thread thread) {
+    return AccountManagementEnablementDeducer.shouldEnable(thread);
   }
 
   protected Resource getLocalApiTokenResource() {

--- a/wavefront-spring-boot/src/test/java/com/wavefront/spring/autoconfigure/AccountManagementIntegrationTests.java
+++ b/wavefront-spring-boot/src/test/java/com/wavefront/spring/autoconfigure/AccountManagementIntegrationTests.java
@@ -1,0 +1,33 @@
+package com.wavefront.spring.autoconfigure;
+
+import com.wavefront.spring.autoconfigure.AccountManagementIntegrationTests.TestConfiguration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests to validate account management does not kick in in a test.
+ *
+ * @author Stephane Nicoll
+ */
+@SpringBootTest(classes = TestConfiguration.class)
+@ExtendWith(OutputCaptureExtension.class)
+class AccountManagementIntegrationTests {
+
+  @Test
+  void accountManagementIsNotProvisionedInTest(CapturedOutput output) {
+    assertThat(output).doesNotContain("Wavefront account");
+  }
+
+  @EnableAutoConfiguration
+  static class TestConfiguration {
+
+  }
+
+}

--- a/wavefront-spring-boot/src/test/java/com/wavefront/spring/autoconfigure/WavefrontTracingIntegrationTests.java
+++ b/wavefront-spring-boot/src/test/java/com/wavefront/spring/autoconfigure/WavefrontTracingIntegrationTests.java
@@ -58,7 +58,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     classes = WavefrontTracingIntegrationTests.Config.class,
     properties = {
-        "management.metrics.export.wavefront.api-token=dummy",
         "wavefront.application.name=IntegratedTracingTests",
         "spring.zipkin.service.name=test_service"
     })


### PR DESCRIPTION
Note: this PR is based on another one so I'll have to rebase once the first one is merged but that extra commit can be reviewed upfront if you have time

