### PR TITLE
Fix daemon thread issue from Wavefront SDKs

### DIFF
--- a/wavefront-spring-boot-bom/pom.xml
+++ b/wavefront-spring-boot-bom/pom.xml
@@ -32,12 +32,12 @@
       <dependency>
         <groupId>com.wavefront</groupId>
         <artifactId>wavefront-opentracing-sdk-java</artifactId>
-        <version>1.17</version>
+        <version>2.0</version>
       </dependency>
       <dependency>
         <groupId>com.wavefront</groupId>
         <artifactId>wavefront-sdk-java</artifactId>
-        <version>2.3</version>
+        <version>2.5</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontSleuthSpanHandler.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontSleuthSpanHandler.java
@@ -109,12 +109,7 @@ final class WavefrontSleuthSpanHandler extends SpanHandler implements Runnable, 
     this.discoveredHeartbeatMetrics = Sets.newConcurrentHashSet();
 
     this.heartbeatMetricsScheduledExecutorService = Executors.newScheduledThreadPool(1,
-        runnable -> {
-          Thread thread = new NamedThreadFactory("sleuth-heart-beater").
-              newThread(runnable);
-          thread.setDaemon(true);
-          return thread;
-        });
+        new NamedThreadFactory("sleuth-heart-beater").setDaemon(true));
 
     // Emit Heartbeats Metrics every 1 min.
     heartbeatMetricsScheduledExecutorService.scheduleAtFixedRate(() -> {

--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontTracingOpenTracingConfiguration.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontTracingOpenTracingConfiguration.java
@@ -27,7 +27,7 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnMissingBean(name = WavefrontTracingSleuthConfiguration.BEAN_NAME)
 class WavefrontTracingOpenTracingConfiguration {
 
-  @Bean
+  @Bean(destroyMethod = "flush")
   @ConditionalOnMissingBean(Tracer.class)
   @ConditionalOnBean(WavefrontSender.class)
   WavefrontTracer wavefrontTracer(WavefrontSender wavefrontSender, ApplicationTags applicationTags,


### PR DESCRIPTION
- Update Wavefront SDKs version.
- Use `flush()` as the destroy method for WavefrontTracer Bean to avoid coordinating close().