### PR TITLE
Remove OpenTracing API from Wavefront starter

### DIFF
--- a/wavefront-spring-boot-bom/pom.xml
+++ b/wavefront-spring-boot-bom/pom.xml
@@ -36,6 +36,11 @@
       </dependency>
       <dependency>
         <groupId>com.wavefront</groupId>
+        <artifactId>wavefront-runtime-sdk-jvm</artifactId>
+        <version>1.1</version>
+      </dependency>
+      <dependency>
+        <groupId>com.wavefront</groupId>
         <artifactId>wavefront-sdk-java</artifactId>
         <version>2.5</version>
       </dependency>

--- a/wavefront-spring-boot-starter/pom.xml
+++ b/wavefront-spring-boot-starter/pom.xml
@@ -28,6 +28,16 @@
     <dependency>
       <groupId>com.wavefront</groupId>
       <artifactId>wavefront-opentracing-sdk-java</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>io.opentracing</groupId>
+          <artifactId>opentracing-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.opentracing</groupId>
+          <artifactId>opentracing-util</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/wavefront-spring-boot/pom.xml
+++ b/wavefront-spring-boot/pom.xml
@@ -27,6 +27,10 @@
     </dependency>
     <dependency>
       <groupId>com.wavefront</groupId>
+      <artifactId>wavefront-runtime-sdk-jvm</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.wavefront</groupId>
       <artifactId>wavefront-sdk-java</artifactId>
     </dependency>
     <dependency>

--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontMetricsConfiguration.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontMetricsConfiguration.java
@@ -4,44 +4,70 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import com.wavefront.sdk.appagent.jvm.reporter.WavefrontJvmReporter;
+import com.wavefront.sdk.common.WavefrontSender;
 import com.wavefront.sdk.common.application.ApplicationTags;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
+import io.micrometer.wavefront.WavefrontConfig;
 import io.micrometer.wavefront.WavefrontMeterRegistry;
 
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.PropertyMapper;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 /**
  * Configuration for Wavefront metrics.
  *
  * @author Stephane Nicoll
+ * @author Tommy Ludwig
  */
-@ConditionalOnClass({ WavefrontMeterRegistry.class, MeterRegistryCustomizer.class })
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnBean(WavefrontSender.class)
 class WavefrontMetricsConfiguration {
 
   @Bean
-  MeterRegistryCustomizer<WavefrontMeterRegistry> wavefrontTagsMeterRegistryCustomizer(
-      ObjectProvider<ApplicationTags> applicationTags) {
-    return (registry) -> applicationTags
-        .ifUnique((appTags) -> registry.config().commonTags(createTagsFrom(appTags)));
+  @ConditionalOnMissingBean
+  @ConditionalOnProperty(name = "wavefront.metrics.extract-jvm-metrics", matchIfMissing = true)
+  WavefrontJvmReporter wavefrontJvmReporter(WavefrontSender wavefrontSender, ApplicationTags applicationTags,
+      WavefrontConfig wavefrontConfig) {
+    WavefrontJvmReporter reporter = new WavefrontJvmReporter.Builder(applicationTags)
+        .withSource(wavefrontConfig.source()).build(wavefrontSender);
+    reporter.start();
+    return reporter;
   }
 
-  private Iterable<Tag> createTagsFrom(ApplicationTags applicationTags) {
-    Map<String, String> tags = new HashMap<>();
-    PropertyMapper mapper = PropertyMapper.get().alwaysApplyingWhenNonNull();
-    mapper.from(applicationTags::getApplication).to((application) -> tags.put("application", application));
-    mapper.from(applicationTags::getService).to((service) -> tags.put("service", service));
-    mapper.from(applicationTags::getCluster).to((cluster) -> tags.put("cluster", cluster));
-    mapper.from(applicationTags::getShard).to((shard) -> tags.put("shard", shard));
-    if (applicationTags.getCustomTags() != null) {
-      tags.putAll(applicationTags.getCustomTags());
+
+  @Configuration(proxyBeanMethods = false)
+  @ConditionalOnClass({ WavefrontMeterRegistry.class, MeterRegistryCustomizer.class })
+  static class MicrometerConfiguration {
+
+    @Bean
+    MeterRegistryCustomizer<WavefrontMeterRegistry> wavefrontTagsMeterRegistryCustomizer(
+        ObjectProvider<ApplicationTags> applicationTags) {
+      return (registry) -> applicationTags
+          .ifUnique((appTags) -> registry.config().commonTags(createTagsFrom(appTags)));
     }
-    return Tags.of(tags.entrySet().stream().map((entry) -> Tag.of(entry.getKey(), entry.getValue()))
-        .collect(Collectors.toList()));
+
+    private Iterable<Tag> createTagsFrom(ApplicationTags applicationTags) {
+      Map<String, String> tags = new HashMap<>();
+      PropertyMapper mapper = PropertyMapper.get().alwaysApplyingWhenNonNull();
+      mapper.from(applicationTags::getApplication).to((application) -> tags.put("application", application));
+      mapper.from(applicationTags::getService).to((service) -> tags.put("service", service));
+      mapper.from(applicationTags::getCluster).to((cluster) -> tags.put("cluster", cluster));
+      mapper.from(applicationTags::getShard).to((shard) -> tags.put("shard", shard));
+      if (applicationTags.getCustomTags() != null) {
+        tags.putAll(applicationTags.getCustomTags());
+      }
+      return Tags.of(tags.entrySet().stream().map((entry) -> Tag.of(entry.getKey(), entry.getValue()))
+          .collect(Collectors.toList()));
+    }
   }
 
 }

--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontProperties.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontProperties.java
@@ -22,6 +22,8 @@ public class WavefrontProperties {
 
   private final Application application = new Application();
 
+  private final Metrics metrics = new Metrics();
+
   private final Tracing tracing = new Tracing();
 
   public Boolean getFreemiumAccount() {
@@ -34,6 +36,10 @@ public class WavefrontProperties {
 
   public Application getApplication() {
     return this.application;
+  }
+
+  public Metrics getMetrics() {
+    return this.metrics;
   }
 
   public Tracing getTracing() {
@@ -99,18 +105,12 @@ public class WavefrontProperties {
 
   }
 
-  public static class Tracing {
+  public static class Metrics {
 
     /**
-     * Extract JMV metrics from traces.
+     * Extract JMV metrics.
      */
     private boolean extractJvmMetrics = true;
-
-    /**
-     * Tags that should be associated with RED metrics. If the span has any of the
-     * specified tags, then those get reported to generated RED metrics.
-     */
-    private Set<String> redMetricsCustomTagKeys = new HashSet<>();
 
     public boolean isExtractJvmMetrics() {
       return this.extractJvmMetrics;
@@ -119,6 +119,16 @@ public class WavefrontProperties {
     public void setExtractJvmMetrics(boolean extractJvmMetrics) {
       this.extractJvmMetrics = extractJvmMetrics;
     }
+
+  }
+
+  public static class Tracing {
+
+    /**
+     * Tags that should be associated with RED metrics. If the span has any of the
+     * specified tags, then those get reported to generated RED metrics.
+     */
+    private Set<String> redMetricsCustomTagKeys = new HashSet<>();
 
     public Set<String> getRedMetricsCustomTagKeys() {
       return this.redMetricsCustomTagKeys;

--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontSleuthSpanHandler.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontSleuthSpanHandler.java
@@ -17,14 +17,11 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import javax.annotation.Nullable;
-
 import brave.handler.MutableSpan;
 import brave.handler.SpanHandler;
 import brave.propagation.TraceContext;
 import com.wavefront.internal.reporter.WavefrontInternalReporter;
 import com.wavefront.java_sdk.com.google.common.collect.Sets;
-import com.wavefront.sdk.appagent.jvm.reporter.WavefrontJvmReporter;
 import com.wavefront.sdk.common.NamedThreadFactory;
 import com.wavefront.sdk.common.Pair;
 import com.wavefront.sdk.common.WavefrontSender;
@@ -82,8 +79,6 @@ final class WavefrontSleuthSpanHandler extends SpanHandler implements Runnable, 
   final LinkedBlockingQueue<Pair<TraceContext, MutableSpan>> spanBuffer;
   final WavefrontSender wavefrontSender;
   final WavefrontInternalReporter wfInternalReporter;
-  @Nullable
-  final WavefrontJvmReporter wfJvmReporter;
   final Set<String> traceDerivedCustomTagKeys;
   final Counter spansDropped;
   final Counter spansReceived;
@@ -128,15 +123,6 @@ final class WavefrontSleuthSpanHandler extends SpanHandler implements Runnable, 
         prefixedWith(TRACING_DERIVED_PREFIX).withSource(DEFAULT_SOURCE).reportMinuteDistribution().
         build(wavefrontSender);
     wfInternalReporter.start(1, TimeUnit.MINUTES);
-
-    if (wavefrontProperties.getTracing().isExtractJvmMetrics()) {
-      wfJvmReporter = new WavefrontJvmReporter.Builder(applicationTags).
-          withSource(source).build(wavefrontSender);
-      // Start the JVM reporter
-      wfJvmReporter.start();
-    } else {
-      wfJvmReporter = null;
-    }
 
     this.source = source;
     this.defaultTags = createDefaultTags(applicationTags, localServiceName);

--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontTracingOpenTracingConfiguration.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontTracingOpenTracingConfiguration.java
@@ -7,7 +7,6 @@ import com.wavefront.opentracing.reporting.Reporter;
 import com.wavefront.opentracing.reporting.WavefrontSpanReporter;
 import com.wavefront.sdk.common.WavefrontSender;
 import com.wavefront.sdk.common.application.ApplicationTags;
-import com.wavefront.spring.autoconfigure.WavefrontProperties.Tracing;
 import io.micrometer.wavefront.WavefrontConfig;
 import io.opentracing.Tracer;
 
@@ -34,12 +33,10 @@ class WavefrontTracingOpenTracingConfiguration {
       WavefrontConfig wavefrontConfig, WavefrontProperties wavefrontProperties) {
     Reporter spanReporter = new WavefrontSpanReporter.Builder().withSource(wavefrontConfig.source())
         .build(wavefrontSender);
-    WavefrontTracer.Builder builder = new WavefrontTracer.Builder(spanReporter, applicationTags);
-    Tracing tracingProperties = wavefrontProperties.getTracing();
-    if (!tracingProperties.isExtractJvmMetrics()) {
-      builder.excludeJvmMetrics();
-    }
-    builder.redMetricsCustomTagKeys(new HashSet<>(tracingProperties.getRedMetricsCustomTagKeys()));
+    WavefrontTracer.Builder builder = new WavefrontTracer.Builder(spanReporter, applicationTags)
+        .excludeJvmMetrics();  // reported separately
+    builder.redMetricsCustomTagKeys(
+        new HashSet<>(wavefrontProperties.getTracing().getRedMetricsCustomTagKeys()));
     return builder.build();
   }
 


### PR DESCRIPTION
This commit excludes the OpenTracing dependency from the wavefront SDK
so that no tracing auto-configuration kicks in when the starter is
added.

Users can opt-in for either Spring Cloud Sleuth or OpenTracing which
will auto-configure the relevant bits to enable tracing.

This commit also makes sure that users that opt-in for Spring Cloud
Sleuth don't have OpenTracing libraries on their classpath.