### PR TITLE
 Turn off unnecessary proxying of configuration classes

### DIFF
--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontAutoConfiguration.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontAutoConfiguration.java
@@ -22,7 +22,7 @@ import org.springframework.core.env.Environment;
  *
  * @author Stephane Nicoll
  */
-@Configuration
+@Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(ApplicationTags.class)
 @EnableConfigurationProperties(WavefrontProperties.class)
 @AutoConfigureAfter(WavefrontMetricsExportAutoConfiguration.class)


### PR DESCRIPTION
In order to avoid unneeded CGLIB proxy and ensure compatibility with GraalVM native images, see related spring-projects-experimental/spring-graalvm-native#199 issue.