### PR TITLE
Remove sample when staging a release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,6 @@
     <module>wavefront-spring-boot</module>
     <module>wavefront-spring-boot-bom</module>
     <module>wavefront-spring-boot-parent</module>
-    <module>wavefront-spring-boot-sample</module>
     <module>wavefront-spring-boot-starter</module>
   </modules>
 
@@ -74,6 +73,17 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>sample</id>
+      <activation>
+        <property>
+          <name>!release</name>
+        </property>
+      </activation>
+      <modules>
+        <module>wavefront-spring-boot-sample</module>
+      </modules>
+    </profile>
     <profile>
       <id>release</id>
       <build>


### PR DESCRIPTION
This commit moves the declaration of the sample module in a separate
profile that is enabled automatically unless the `release` property is
set.

If a release is invoked with `-Drelease`, this has the effect of
removing that module for the reactor and therefore from the staging
area.