### PR TITLE
Revert version update due to OSSRH rule failures for sample

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.wavefront</groupId>
   <artifactId>wavefront-spring-boot-build</artifactId>
-  <version>2.0.1-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Wavefront Spring Boot Build</name>
   <description>Wavefront by VMware integration for Spring Boot</description>

--- a/wavefront-spring-boot-bom/pom.xml
+++ b/wavefront-spring-boot-bom/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.wavefront</groupId>
     <artifactId>wavefront-spring-boot-build</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
   <artifactId>wavefront-spring-boot-bom</artifactId>

--- a/wavefront-spring-boot-parent/pom.xml
+++ b/wavefront-spring-boot-parent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.wavefront</groupId>
     <artifactId>wavefront-spring-boot-bom</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../wavefront-spring-boot-bom</relativePath>
   </parent>
   <artifactId>wavefront-spring-boot-parent</artifactId>

--- a/wavefront-spring-boot-sample/pom.xml
+++ b/wavefront-spring-boot-sample/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.wavefront</groupId>
     <artifactId>wavefront-spring-boot-parent</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../wavefront-spring-boot-parent</relativePath>
   </parent>
   <artifactId>wavefront-spring-boot-sample</artifactId>

--- a/wavefront-spring-boot-starter/pom.xml
+++ b/wavefront-spring-boot-starter/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.wavefront</groupId>
     <artifactId>wavefront-spring-boot-parent</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../wavefront-spring-boot-parent</relativePath>
   </parent>
   <artifactId>wavefront-spring-boot-starter</artifactId>

--- a/wavefront-spring-boot/pom.xml
+++ b/wavefront-spring-boot/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.wavefront</groupId>
     <artifactId>wavefront-spring-boot-parent</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../wavefront-spring-boot-parent</relativePath>
   </parent>
   <artifactId>wavefront-spring-boot</artifactId>


### PR DESCRIPTION
still failing with sample java-doc module with this command

```
$ java -Dmaven.test.failure.ignore=false -DskipTests -DreleaseType=final -Drelease -cp /home/ubuntu/maven35-agent.jar:/home/ubuntu/tools/hudson.tasks.Maven_MavenInstallation/mvn-3.5.3/boot/plexus-classworlds-2.5.2.jar:/home/ubuntu/tools/hudson.tasks.Maven_MavenInstallation/mvn-3.5.3/conf/logging jenkins.maven3.agent.Maven35Main /home/ubuntu/tools/hudson.tasks.Maven_MavenInstallation/mvn-3.5.3 /tmp/remoting.jar /home/ubuntu/maven35-interceptor.jar /home/ubuntu/maven3-interceptor-commons.jar 45449
02:43:11 <===[JENKINS REMOTING CAPACITY]===>channel started
02:43:13 Executing Maven:  -B -f /home/ubuntu/workspace/wavefront-spring-boot-prepare-perform/wavefront-spring-boot/pom.xml -s /home/ubuntu/workspace/wavefront-spring-boot-prepare-perform/settings.xml -B release:prepare -DautoVersionSubmodules=true -DreleaseVersion=2.0.0 -DdevelopmentVersion=2.0.1-SNAPSHOT release:perform -P release
```

```
2:53:14 [INFO] [ERROR] Nexus Staging Rules Failure Report
02:53:14 [INFO] [ERROR] ==================================
02:53:14 [INFO] [ERROR] 
02:53:14 [INFO] [ERROR] Repository "comwavefront-1336" failures
02:53:14 [INFO] [ERROR]   Rule "javadoc-staging" failures
02:53:14 [INFO] [ERROR]     * Missing: no javadoc jar found in folder '/com/wavefront/wavefront-spring-boot-sample/2.0.0'
02:53:14 [INFO] [ERROR] 
```

I have made a fix on the jenkins side to change the way we invoke maven release plugin, hopefully will try 1 more time.