### PR TITLE
Revert version update due to OSSRH rule failures for sample

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.wavefront</groupId>
   <artifactId>wavefront-spring-boot-build</artifactId>
-  <version>2.0.1-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Wavefront Spring Boot Build</name>
   <description>Wavefront by VMware integration for Spring Boot</description>

--- a/wavefront-spring-boot-bom/pom.xml
+++ b/wavefront-spring-boot-bom/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.wavefront</groupId>
     <artifactId>wavefront-spring-boot-build</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
   <artifactId>wavefront-spring-boot-bom</artifactId>

--- a/wavefront-spring-boot-parent/pom.xml
+++ b/wavefront-spring-boot-parent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.wavefront</groupId>
     <artifactId>wavefront-spring-boot-bom</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../wavefront-spring-boot-bom</relativePath>
   </parent>
   <artifactId>wavefront-spring-boot-parent</artifactId>

--- a/wavefront-spring-boot-starter/pom.xml
+++ b/wavefront-spring-boot-starter/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.wavefront</groupId>
     <artifactId>wavefront-spring-boot-parent</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../wavefront-spring-boot-parent</relativePath>
   </parent>
   <artifactId>wavefront-spring-boot-starter</artifactId>

--- a/wavefront-spring-boot/pom.xml
+++ b/wavefront-spring-boot/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.wavefront</groupId>
     <artifactId>wavefront-spring-boot-parent</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../wavefront-spring-boot-parent</relativePath>
   </parent>
   <artifactId>wavefront-spring-boot</artifactId>


### PR DESCRIPTION
command used:
`Executing Maven:  -B -f /home/ubuntu/workspace/wavefront-spring-boot-prepare-perform/wavefront-spring-boot/pom.xml -s /home/ubuntu/workspace/wavefront-spring-boot-prepare-perform/settings.xml -B release:prepare -DskipTests -DreleaseType=final -Drelease -DautoVersionSubmodules=true -DreleaseVersion=2.0.0 -DdevelopmentVersion=2.0.1-SNAPSHOT release:perform -P release -Darguments=-Drelease`

failures:
`[INFO] [ERROR] Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:2.7:deploy (default-deploy) on project wavefront-spring-boot-bom: Deployment failed: repository element was not specified in the POM inside distributionManagement element or in -DaltDeploymentRepository=id::layout::url parameter -> [Help 1]`

I think i know why this happened, and solution is to separate out release:prepare / release:perform steps so that `-D` properties are correctly propagated to maven release plugin.