### PR TITLE
Review Getting started instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,52 +35,58 @@ This allows you to see the setup for the Spring Boot generation your project is 
 
 For completeness, here is what you should follow to configure your project.
 
-> **Note**: The `2.0.1` version is the latest version of the starter. [start.spring.io](https://start.spring.io) maintains at all times which version of this starter should be used with the Spring Boot generation you are using.
+> **Note**: The 2.0.1 version is the latest version of the starter. The Wavefront for Spring Boot dependency needs to be compatible with the Spring Boot release version. See [System Requirements](https://docs.wavefront.com/wavefront_springboot.html#versionCompatibility) to get the correct dependency version.
 
-The core setup consists of importing the `wavefront-spring-boot` Bill Of Materials (BOM).
+Configure your project using Maven or Gradle.
 
-```xml
-<dependencyManagement>
-  <dependencies>
-    <dependency>
-      <groupId>com.wavefront</groupId>
-      <artifactId>wavefront-spring-boot</artifactId>
-      <version>2.0.1</version>
-      <type>pom</type>
-      <scope>import</scope>
-    </dependency>
-  </dependencies>
-</dependencyManagement>
-```
+**Maven**
 
-If you are using Gradle, make sure your project uses the `io.spring.dependency-management` plugin and add the following to your `build.gradle` file:
+- The core setup consists of importing the `wavefront-spring-boot` Bill Of Materials (BOM).
 
-```
-dependencyManagement {
-  imports {
-    mavenBom "com.wavefront:wavefront-spring-boot-bom:2.0.1"
+  ```
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.wavefront</groupId>
+        <artifactId>wavefront-spring-boot</artifactId>
+        <version>2.0.1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  ```
+
+- Add the `wavefront-spring-boot-starter` to your project.
+
+  ```
+  <dependency>
+    <groupId>com.wavefront</groupId>
+    <artifactId>wavefront-spring-boot-starter</artifactId>
+  </dependency>
+  ```
+
+**Gradle**
+
+- If you are using Gradle, make sure your project uses the `io.spring.dependency-management` plugin and add the following to your build.gradle file:
+
+  ```
+  dependencyManagement {
+    imports {
+      mavenBom "com.wavefront:wavefront-spring-boot-bom:2.0.1"
+    }
   }
-}
-```
+  ```
 
-You can then add `wavefront-spring-boot-starter` to your project. With Maven:
+- Add the `wavefront-spring-boot-starter` to your project.
 
-```xml
-<dependency>
-  <groupId>com.wavefront</groupId>
-  <artifactId>wavefront-spring-boot-starter</artifactId>
-</dependency>
-```
+  ```
+  dependencies {
+    ...
+    implementation 'com.wavefront:wavefront-spring-boot-starter'
 
-Or, if you are using Gradle:
-
-```
-dependencies {
-  ...
-  implementation 'com.wavefront:wavefront-spring-boot-starter'
-
-}
-```
+  }
+  ```
 
 Each time you restart your application, it either creates a new freemium account, or it restores from `~/.wavefront_freemium`.
 At the end of the startup phase, the console displays a message with a login URL.
@@ -102,47 +108,54 @@ https://wavefront.surf/us/example
 
 If you'd like to send traces to Wavefront, you can do so using [Spring Cloud Sleuth](https://spring.io/projects/spring-cloud-sleuth) or [OpenTracing](https://opentracing.io/).
 
-To configure Spring Cloud in your existing project, you can explore a new project on [start.spring.io](https://start.spring.io) and review the build configuration for your favorite build system.
-Each Spring Boot generation has a matching Spring Cloud generation. Check [the project page](https://spring.io/projects/spring-cloud#release-trains) for more details.
+**Spring Cloud Sleuth**
 
-After you've added the `spring-cloud-dependencies` BOM, you can add Spring Cloud Sleuth as follows:
+Each Spring Boot generation has a matching Spring Cloud generation.
+You can run a simple command and find out the Spring Cloud version that is compatible with your Spring Boot version.
+See [Spring Cloud Version Given Spring Boot Version](https://spring-cloud-info.cfapps.io/docs/spring-cloud-info.html#_spring_cloud_version_given_spring_boot_version) for details. 
 
-```xml
-<dependency>
-  <groupId>org.springframework.cloud</groupId>
-  <artifactId>spring-cloud-starter-sleuth</artifactId>
-</dependency>
-```
+After you've added the spring-cloud-dependencies BOM, you can add Spring Cloud Sleuth as follows:
 
-Or, if you are using Gradle, add the following dependency to the `build.gradle` file:
+- Maven: Add the following dependency to the `pom.xml` file
 
-```
-dependencies {
-  ...
-  implementation 'org.springframework.cloud:spring-cloud-starter-sleuth'
+  ```
+  <dependency>
+    <groupId>org.springframework.cloud</groupId>
+    <artifactId>spring-cloud-starter-sleuth</artifactId>
+  </dependency>
+  ```
+  
+- Gradle: Add the following dependency to the `build.gradle` file:
 
-}
-```
+  ```
+  dependencies {
+    ...
+    implementation 'org.springframework.cloud:spring-cloud-starter-sleuth'
+  }
+  ```
 
-If you prefer to use OpenTracing, add the following dependencies to your `pom.xml` file:
+**OpenTracing**
+  
+Configure your `pom.xml` file or the `build.gradle` file.
 
-```xml
+- Maven: Add the following dependencies to your `pom.xml` file:
+
+  ```
   <dependency>
     <groupId>io.opentracing.contrib</groupId>
     <artifactId>opentracing-spring-cloud-starter</artifactId>
     <version>0.5.7</version>
   </dependency>
-```
+  ```
 
-Of, if you are using Gradle, add the following dependencies to the `build.gradle` file:
+- Gradle: Add the following dependencies to the `build.gradle` file:
 
-```
-dependencies {
-  ...
-  implementation 'io.opentracing.contrib:opentracing-spring-cloud-starter:0.5.7'
-
-}
-```
+  ```
+  dependencies {
+    ...
+    implementation 'io.opentracing.contrib:opentracing-spring-cloud-starter:0.5.7'
+  }
+  ```
 
 ## Building
 To build the latest state of this project, invoke the following command from the root directory:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This project provides a Spring Boot starter for Wavefront. Add the starter to a 
 
 * [Prerequisites](#prerequisites)
 * [Getting Started](#getting-started)
+* [Building](#building)
 * [Custom Configuration](#custom-configuration)
 * [Documentation](#documentation)
 * [License](#license)
@@ -16,125 +17,147 @@ This project provides a Spring Boot starter for Wavefront. Add the starter to a 
 * Spring Boot 2.3 or above
 * Java 8 or above
 * Maven 3.3+ or Gradle 6.3 or later\
-  See [System Requirements](https://docs.spring.io/spring-boot/docs/2.3.0.RELEASE/reference/html/getting-started.html#getting-started-system-requirements) in the Spring Boot documentation.
+  See [System Requirements](https://docs.spring.io/spring-boot/docs/2.3.x/reference/html/getting-started.html#getting-started-system-requirements) in the Spring Boot documentation.
 
-> Note: This starter reuses the [existing Wavefront support](https://docs.spring.io/spring-boot/docs/2.3.0.RELEASE/reference/html/production-ready-features.html#production-ready-metrics-export-wavefront)
+> Note: This starter reuses the [existing Wavefront support](https://docs.spring.io/spring-boot/docs/2.3.x/reference/html/production-ready-features.html#production-ready-metrics-export-wavefront)
 in Spring Boot and provides the Actuator (i.e., `spring-boot-starter-actuator`).
 
 ## Getting Started
 
-* If you want to start from scratch, build the
-project first. Invoke the following command in the root directory:
+The easiest way to get started is to create a new project on [start.spring.io](https://start.spring.io).
+Select Spring Boot `2.3.0` or later and define the other parameters for your project.
+Click "Add dependency" and select `Wavefront` from the dependency list. 
+ 
+If you want to opt-in for tracing support, add the "[Spring Cloud Sleuth](https://spring.io/projects/spring-cloud-sleuth)" entry as well.
 
-  ```shell script
-  $ ./mvnw clean install
-  ```
-* Start a sample web app on `localhost:8080` to see the basic usage of the starter. Invoke the following command in the root directory:
+If you already have a Spring Boot application, you can also use [start.spring.io](https://start.spring.io) to explore a new project from your browser.
+This allows you to see the setup for the Spring Boot generation your project is using. 
 
-  ```shell script
-  $ ./mvnw spring-boot:run -pl wavefront-spring-boot-sample
-  ```
+For completeness, here is what you should follow to configure your project.
 
-* If you already have a Spring Boot application, be sure to use Spring Boot 2.3 or later and add the following dependency to your `pom.xml` file:
+> **Note**: The `2.0.1` version is the latest version of the starter. [start.spring.io](https://start.spring.io) maintains at all times which version of this starter should be used with the Spring Boot generation you are using.
 
-    ```xml
+The core setup consists of importing the `wavefront-spring-boot` Bill Of Materials (BOM).
+
+```xml
+<dependencyManagement>
+  <dependencies>
     <dependency>
       <groupId>com.wavefront</groupId>
-      <artifactId>wavefront-spring-boot-starter</artifactId>
-      <version>2.0.0</version>
+      <artifactId>wavefront-spring-boot</artifactId>
+      <version>2.0.1</version>
+      <type>pom</type>
+      <scope>import</scope>
     </dependency>
-    ```
+  </dependencies>
+</dependencyManagement>
+```
 
-    If you are using Gradle, add the following dependency to your `build.gradle` file:
+If you are using Gradle, make sure your project uses the `io.spring.dependency-management` plugin and add the following to your `build.gradle` file:
 
-    ```
-    dependencies {
-      ...
-      implementation 'com.wavefront:wavefront-spring-boot-starter:2.0.0'
-      
-    }
-    ```
+```
+dependencyManagement {
+  imports {
+    mavenBom "com.wavefront:wavefront-spring-boot-bom:2.0.1"
+  }
+}
+```
 
-    The example below uses the correct dependency versions.
-    ```xml
-    <dependencies>
-      <dependency>
-        <groupId>com.wavefront</groupId>
-        <artifactId>wavefront-spring-boot-starter</artifactId>
-      </dependency>
-    </dependencies>
+You can then add `wavefront-spring-boot-starter` to your project. With Maven:
 
-    <dependencyManagement>
-      <dependencies>
-        <dependency>
-          <groupId>com.wavefront</groupId>
-          <artifactId>wavefront-spring-boot</artifactId>
-          <version>2.0.0</version>
-          <type>pom</type>
-          <scope>import</scope>
-        </dependency>
-      </dependencies>
-    </dependencyManagement>
-    ```
+```xml
+<dependency>
+  <groupId>com.wavefront</groupId>
+  <artifactId>wavefront-spring-boot-starter</artifactId>
+</dependency>
+```
 
-* Each time you restart your application, it either creates a new freemium account, or it restores from `~/.wavefront_freemium`. At the end of the startup phase, the console displays a message with a login URL. Use it to log in to the Wavefront service and access the data that
-  has been collected so far.
+Or, if you are using Gradle:
 
-  Here is an example message when an existing account is restored from `~/.wavefront_freemium`:
+```
+dependencies {
+  ...
+  implementation 'com.wavefront:wavefront-spring-boot-starter'
 
-  ```text
-    Your existing Wavefront account information has been restored from disk.
+}
+```
 
-    management.metrics.export.wavefront.api-token=2c96d63a-abcd-efgh-ijhk-841611451e07
-    management.metrics.export.wavefront.uri=https://wavefront.surf
+Each time you restart your application, it either creates a new freemium account, or it restores from `~/.wavefront_freemium`.
+At the end of the startup phase, the console displays a message with a login URL.
+Use it to log in to the Wavefront service and access the data that has been collected so far.
 
-    Connect to your Wavefront dashboard using this one-time use link:
-    https://wavefront.surf/us/example
-  ```
+Here is an example message when an existing account is restored from `~/.wavefront_freemium`:
 
-* Add the following dependency to send traces to Wavefront using 
-[Spring Cloud Sleuth](https://spring.io/projects/spring-cloud-sleuth) or [OpenTracing](https://opentracing.io/).
+```text
+Your existing Wavefront account information has been restored from disk.
 
-  * **Spring Cloud Sleuth**: 
-    
-    Add the following dependency to your `pom.xml` file:
+management.metrics.export.wavefront.api-token=2c96d63a-abcd-efgh-ijhk-841611451e07
+management.metrics.export.wavefront.uri=https://wavefront.surf
 
-    ```xml
-    <dependency>
-      <groupId>org.springframework.cloud</groupId>
-      <artifactId>spring-cloud-starter-sleuth</artifactId>
-      <version>2.2.4.RELEASE</version>
-    </dependency>
-    ```
+Connect to your Wavefront dashboard using this one-time use link:
+https://wavefront.surf/us/example
+```
 
-    If you are using Gradle, add the following dependency to the `build.gradle` file:
+## Tracing Support
 
-    ```
-    dependencies {
-      ...
-      implementation 'org.springframework.cloud:spring-cloud-starter-sleuth:2.2.3.RELEASE'
+If you'd like to send traces to Wavefront, you can do so using [Spring Cloud Sleuth](https://spring.io/projects/spring-cloud-sleuth) or [OpenTracing](https://opentracing.io/).
 
-    }
-    ```
-  * **OpenTracing**
-    
-    Add the following dependencies to your `pom.xml` file:
-    ```xml
-      <dependency>
-        <groupId>io.opentracing.contrib</groupId>
-        <artifactId>opentracing-spring-cloud-starter</artifactId>
-        <version>0.5.3</version>
-      </dependency>
-    ```
-    If you are using Gradle, add the following dependencies to the `build.gradle` file:
+To configure Spring Cloud in your existing project, you can explore a new project on [start.spring.io](https://start.spring.io) and review the build configuration for your favorite build system.
+Each Spring Boot generation has a matching Spring Cloud generation. Check [the project page](https://spring.io/projects/spring-cloud#release-trains) for more details.
 
-    ```
-    dependencies {
-      ...
-      implementation 'io.opentracing.contrib:opentracing-spring-cloud-starter:0.5.3'
+After you've added the `spring-cloud-dependencies` BOM, you can add Spring Cloud Sleuth as follows:
 
-    }
-    ```
+```xml
+<dependency>
+  <groupId>org.springframework.cloud</groupId>
+  <artifactId>spring-cloud-starter-sleuth</artifactId>
+</dependency>
+```
+
+Or, if you are using Gradle, add the following dependency to the `build.gradle` file:
+
+```
+dependencies {
+  ...
+  implementation 'org.springframework.cloud:spring-cloud-starter-sleuth'
+
+}
+```
+
+If you prefer to use OpenTracing, add the following dependencies to your `pom.xml` file:
+
+```xml
+  <dependency>
+    <groupId>io.opentracing.contrib</groupId>
+    <artifactId>opentracing-spring-cloud-starter</artifactId>
+    <version>0.5.7</version>
+  </dependency>
+```
+
+Of, if you are using Gradle, add the following dependencies to the `build.gradle` file:
+
+```
+dependencies {
+  ...
+  implementation 'io.opentracing.contrib:opentracing-spring-cloud-starter:0.5.7'
+
+}
+```
+
+## Building
+To build the latest state of this project, invoke the following command from the root directory:
+
+```shell script
+$ ./mvnw clean install
+```
+
+The project has a sample that showcases the basic usage of the starter.
+It starts a web app on `localhost:8080`.
+Invoke the following command from the root directory:
+
+```shell script
+$ ./mvnw spring-boot:run -pl wavefront-spring-boot-sample
+```
 
 ## Documentation
 


### PR DESCRIPTION
This is a review of the getting started instructions for Wavefront. 

This covers several areas:
* Recommend the use of the BOM so that dependencies required by this starter are managed. In particular, if the version of the SDK micrometer uses is slightly behind, importing the BOM makes sure that the version of the SDK we intend is used
* Recommend to use start.spring.io for new projects. This is by far the easiest to get started. start.spring.io has also a "Expore" feature where you can see the content of a project without downloading it. That way you can peek at the build file and figure out yourself what you need to add to your project
* Stop hardcoding a version for Sleuth. This is problematic as those things move out of our control and  we can't remember to update the page whenever a new version is available (`2.2.5.RELEASE` is out today). Also, if a user already uses Spring Cloud they already have the Spring Cloud BOM so instructing them to add the starter with a version is a bad idea
* Move the building section down. Previously, building the project was required as we didn't have any snapshot, it shouldn't be front and center anymore.

@shavidissa I'd need your advices in particular on how to showcase the "Explore" part. I don't think I've phrased that clearly enough. 

