### PR TITLE
Add additional customization and configuration options for OpenTracing

### DIFF
--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontProperties.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontProperties.java
@@ -127,7 +127,7 @@ public class WavefrontProperties {
 
   public static class Tracing {
 
-    private final OpenTracing openTracing = new OpenTracing();
+    private final Opentracing opentracing = new Opentracing();
 
     /**
      * Tags that should be associated with RED metrics. If the span has any of the
@@ -135,13 +135,8 @@ public class WavefrontProperties {
      */
     private Set<String> redMetricsCustomTagKeys = new HashSet<>();
 
-    /**
-     * Global tags included with every reported span.
-     */
-    private Map<String, String> tags = new HashMap<>();
-
-    public OpenTracing getOpenTracing() {
-      return this.openTracing;
+    public Opentracing getOpentracing() {
+      return this.opentracing;
     }
 
     public Set<String> getRedMetricsCustomTagKeys() {
@@ -152,15 +147,7 @@ public class WavefrontProperties {
       this.redMetricsCustomTagKeys = redMetricsCustomTagKeys;
     }
 
-    public Map<String, String> getTags() {
-      return this.tags;
-    }
-
-    public void setTags(Map<String, String> tags) {
-      this.tags = tags;
-    }
-
-    public static class OpenTracing {
+    public static class Opentracing {
 
       private final Sampler sampler = new Sampler();
 

--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontProperties.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontProperties.java
@@ -1,6 +1,9 @@
 package com.wavefront.spring.autoconfigure;
 
+import java.time.Duration;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -124,11 +127,22 @@ public class WavefrontProperties {
 
   public static class Tracing {
 
+    private final OpenTracing openTracing = new OpenTracing();
+
     /**
      * Tags that should be associated with RED metrics. If the span has any of the
      * specified tags, then those get reported to generated RED metrics.
      */
     private Set<String> redMetricsCustomTagKeys = new HashSet<>();
+
+    /**
+     * Global tags included with every reported span.
+     */
+    private Map<String, String> tags = new HashMap<>();
+
+    public OpenTracing getOpenTracing() {
+      return this.openTracing;
+    }
 
     public Set<String> getRedMetricsCustomTagKeys() {
       return this.redMetricsCustomTagKeys;
@@ -136,6 +150,56 @@ public class WavefrontProperties {
 
     public void setRedMetricsCustomTagKeys(Set<String> redMetricsCustomTagKeys) {
       this.redMetricsCustomTagKeys = redMetricsCustomTagKeys;
+    }
+
+    public Map<String, String> getTags() {
+      return this.tags;
+    }
+
+    public void setTags(Map<String, String> tags) {
+      this.tags = tags;
+    }
+
+    public static class OpenTracing {
+
+      private final Sampler sampler = new Sampler();
+
+      public Sampler getSampler() {
+        return this.sampler;
+      }
+
+      public static class Sampler {
+
+        /**
+         * Probabilistic rate (between 0.0 and 1.0) of requests that should be sampled. If not
+         * specified, probabilistic sampling is not applied.
+         */
+        private Double probability;
+
+        /**
+         * Spans longer than this duration are sampled. If not specified, duration sampling is
+         * not applied.
+         */
+        private Duration duration;
+
+        public Double getProbability() {
+          return this.probability;
+        }
+
+        public void setProbability(Double probability) {
+          this.probability = probability;
+        }
+
+        public Duration getDuration() {
+          return this.duration;
+        }
+
+        public void setDuration(Duration duration) {
+          this.duration = duration;
+        }
+
+      }
+
     }
 
   }

--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontSleuthSpanHandler.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontSleuthSpanHandler.java
@@ -4,7 +4,6 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -79,7 +78,6 @@ final class WavefrontSleuthSpanHandler extends SpanHandler implements Runnable, 
   final WavefrontSender wavefrontSender;
   final WavefrontInternalReporter wfInternalReporter;
   final Set<String> traceDerivedCustomTagKeys;
-  final Map<String, String> globalSpanTags;
   final Counter spansDropped;
   final Counter spansReceived;
   final Counter reportErrors;
@@ -116,7 +114,6 @@ final class WavefrontSleuthSpanHandler extends SpanHandler implements Runnable, 
 
     this.traceDerivedCustomTagKeys = new HashSet<>(
         wavefrontProperties.getTracing().getRedMetricsCustomTagKeys());
-    this.globalSpanTags = new HashMap<>(wavefrontProperties.getTracing().getTags());
 
     // Start the reporter
     wfInternalReporter = new WavefrontInternalReporter.Builder().
@@ -185,7 +182,7 @@ final class WavefrontSleuthSpanHandler extends SpanHandler implements Runnable, 
     long durationMillis = startMillis != 0 && finishMillis != 0L ? Math.max(finishMillis - startMillis, 1L) : 0L;
 
     List<SpanLog> spanLogs = convertAnnotationsToSpanLogs(span);
-    TagList tags = new TagList(defaultTagKeys, defaultTags, globalSpanTags, context, span);
+    TagList tags = new TagList(defaultTagKeys, defaultTags, context, span);
 
     try {
       wavefrontSender.sendSpan(name, startMillis, durationMillis, source, traceId, spanId,
@@ -222,30 +219,38 @@ final class WavefrontSleuthSpanHandler extends SpanHandler implements Runnable, 
    * the component tag and error status.
    */
   static final class TagList extends ArrayList<Pair<String, String>> {
-    private final Set<String> defaultTagKeys;
-    private boolean debug;
-
     String componentTagValue = NULL_TAG_VAL;
     boolean isError; // See explanation here: https://github.com/openzipkin/brave/pull/1221
 
     TagList(
         Set<String> defaultTagKeys,
         List<Pair<String, String>> defaultTags,
-        Map<String, String> globalSpanTags,
         TraceContext context,
         MutableSpan span
     ){
-      super(defaultTags.size() + globalSpanTags.size() + span.tagCount());
-      this.defaultTagKeys = defaultTagKeys;
-      debug = context.debug();
+      super(defaultTags.size() + span.tagCount());
+      boolean debug = context.debug(), hasAnnotations = span.annotationCount() > 0;
       isError = span.error() != null;
-      boolean hasAnnotations = span.annotationCount() > 0;
 
       int tagCount = span.tagCount();
       addAll(defaultTags);
-      globalSpanTags.forEach(this::addTag);
       for (int i = 0; i < tagCount; i++) {
-        addTag(span.tagKeyAt(i), span.tagValueAt(i));
+        String key = span.tagKeyAt(i), value = span.tagValueAt(i);
+        String lcKey = key.toLowerCase(Locale.ROOT);
+        if (lcKey.equals(ERROR_TAG_KEY)) {
+          isError = true;
+          continue; // We later replace whatever the potentially empty value was with "true"
+        }
+        if (value.isEmpty()) continue;
+        if (defaultTagKeys.contains(lcKey)) continue;
+        if (lcKey.equals(DEBUG_TAG_KEY)) {
+          debug = true; // This tag is set out-of-band
+          continue;
+        }
+        if (lcKey.equals(COMPONENT_TAG_KEY)) {
+          componentTagValue = value;
+        }
+        add(Pair.of(key, value));
       }
 
       // Check for span.error() for uncaught exception in request mapping and add it to Wavefront span tag
@@ -270,24 +275,6 @@ final class WavefrontSleuthSpanHandler extends SpanHandler implements Runnable, 
       if (span.localIp() != null) {
         add(Pair.of("ipv4", span.localIp())); // NOTE: this could be IPv6!!
       }
-    }
-
-    private void addTag(String key, String value) {
-      String lcKey = key.toLowerCase(Locale.ROOT);
-      if (lcKey.equals(ERROR_TAG_KEY)) {
-        isError = true;
-        return; // We later replace whatever the potentially empty value was with "true"
-      }
-      if (value.isEmpty()) return;
-      if (defaultTagKeys.contains(lcKey)) return;
-      if (lcKey.equals(DEBUG_TAG_KEY)) {
-        debug = true; // This tag is set out-of-band
-        return;
-      }
-      if (lcKey.equals(COMPONENT_TAG_KEY)) {
-        componentTagValue = value;
-      }
-      add(Pair.of(key, value));
     }
   }
 

--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontTracerBuilderCustomizer.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontTracerBuilderCustomizer.java
@@ -1,0 +1,21 @@
+package com.wavefront.spring.autoconfigure;
+
+import com.wavefront.opentracing.WavefrontTracer;
+
+/**
+ * Callback interface that can be implemented by beans wishing to customize the
+ * {@link WavefrontTracer} via a {@link WavefrontTracer.Builder} whilst retaining default
+ * auto-configuration.
+ *
+ * @author Han Zhang
+ */
+@FunctionalInterface
+public interface WavefrontTracerBuilderCustomizer {
+
+  /**
+   * Customize the {@link WavefrontTracer.Builder}.
+   * @param builder the builder to customize
+   */
+  void customize(WavefrontTracer.Builder builder);
+
+}

--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontTracingOpenTracingConfiguration.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontTracingOpenTracingConfiguration.java
@@ -2,7 +2,6 @@ package com.wavefront.spring.autoconfigure;
 
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 
@@ -60,15 +59,14 @@ class WavefrontTracingOpenTracingConfiguration {
         .excludeJvmMetrics();  // reported separately
     builder.redMetricsCustomTagKeys(
         new HashSet<>(wavefrontProperties.getTracing().getRedMetricsCustomTagKeys()));
-    builder.withGlobalTags(new HashMap<>(wavefrontProperties.getTracing().getTags()));
     List<Sampler> samplers =
-        createSampler(wavefrontProperties.getTracing().getOpenTracing().getSampler());
+        createSamplers(wavefrontProperties.getTracing().getOpentracing().getSampler());
     samplers.forEach(builder::withSampler);
     customizers.orderedStream().forEach((customizer) -> customizer.customize(builder));
     return builder.build();
   }
 
-  private List<Sampler> createSampler(WavefrontProperties.Tracing.OpenTracing.Sampler samplerProperties) {
+  private List<Sampler> createSamplers(WavefrontProperties.Tracing.Opentracing.Sampler samplerProperties) {
     Double probability = samplerProperties.getProbability();
     Duration duration = samplerProperties.getDuration();
     List<Sampler> samplers = new ArrayList<>();

--- a/wavefront-spring-boot/src/test/java/com/wavefront/spring/autoconfigure/WavefrontAutoConfigurationTests.java
+++ b/wavefront-spring-boot/src/test/java/com/wavefront/spring/autoconfigure/WavefrontAutoConfigurationTests.java
@@ -2,7 +2,6 @@ package com.wavefront.spring.autoconfigure;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -259,7 +258,6 @@ class WavefrontAutoConfigurationTests {
     WavefrontSender sender = mock(WavefrontSender.class);
     this.contextRunner.withPropertyValues()
         .withPropertyValues("wavefront.tracing.red-metrics-custom-tag-keys=region,test")
-        .withPropertyValues("wavefront.tracing.tags.hello=world")
         .with(wavefrontMetrics(() -> sender))
         .with(sleuth())
         .run((context) -> {
@@ -268,10 +266,6 @@ class WavefrontAutoConfigurationTests {
           Set<String> traceDerivedCustomTagKeys = (Set<String>) ReflectionTestUtils.getField(
               spanHandler, "traceDerivedCustomTagKeys");
           assertThat(traceDerivedCustomTagKeys).containsExactlyInAnyOrder("region", "test");
-          Map<String, String> tags = (Map<String, String>) ReflectionTestUtils.getField(
-              spanHandler, "globalSpanTags");
-          assertThat(tags).containsExactlyInAnyOrderEntriesOf(Collections.singletonMap("hello",
-              "world"));
         });
   }
 
@@ -295,7 +289,6 @@ class WavefrontAutoConfigurationTests {
     this.contextRunner
         .withClassLoader(new FilteredClassLoader("org.springframework.cloud.sleuth"))
         .withPropertyValues("wavefront.tracing.red-metrics-custom-tag-keys=region,test")
-        .withPropertyValues("wavefront.tracing.tags.hello=world")
         .withPropertyValues("wavefront.tracing.opentracing.sampler.probability=0.1")
         .withPropertyValues("wavefront.tracing.opentracing.sampler.duration=2s")
         .with(wavefrontMetrics(() -> {
@@ -311,9 +304,6 @@ class WavefrontAutoConfigurationTests {
           Set<String> redMetricsCustomTagKeys = (Set<String>) ReflectionTestUtils.getField(wavefrontTracer,
               "redMetricsCustomTagKeys");
           assertThat(redMetricsCustomTagKeys).containsExactlyInAnyOrder("span.kind", "region", "test");
-          List<Pair<String, String>> tags = (List<Pair<String, String>>) ReflectionTestUtils.getField(
-              wavefrontTracer, "tags");
-          assertThat(tags).contains(Pair.of("hello", "world"));
           List<Sampler> samplers = (List<Sampler>) ReflectionTestUtils.getField(wavefrontTracer,
               "samplers");
           assertThat(samplers).hasSize(2);

--- a/wavefront-spring-boot/src/test/java/com/wavefront/spring/autoconfigure/WavefrontAutoConfigurationTests.java
+++ b/wavefront-spring-boot/src/test/java/com/wavefront/spring/autoconfigure/WavefrontAutoConfigurationTests.java
@@ -1,5 +1,8 @@
 package com.wavefront.spring.autoconfigure;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -13,6 +16,7 @@ import com.wavefront.sdk.appagent.jvm.reporter.WavefrontJvmReporter;
 import com.wavefront.sdk.common.Pair;
 import com.wavefront.sdk.common.WavefrontSender;
 import com.wavefront.sdk.common.application.ApplicationTags;
+import com.wavefront.sdk.entities.tracing.sampling.Sampler;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.junit.jupiter.api.Test;
 
@@ -255,6 +259,7 @@ class WavefrontAutoConfigurationTests {
     WavefrontSender sender = mock(WavefrontSender.class);
     this.contextRunner.withPropertyValues()
         .withPropertyValues("wavefront.tracing.red-metrics-custom-tag-keys=region,test")
+        .withPropertyValues("wavefront.tracing.tags.hello=world")
         .with(wavefrontMetrics(() -> sender))
         .with(sleuth())
         .run((context) -> {
@@ -263,6 +268,10 @@ class WavefrontAutoConfigurationTests {
           Set<String> traceDerivedCustomTagKeys = (Set<String>) ReflectionTestUtils.getField(
               spanHandler, "traceDerivedCustomTagKeys");
           assertThat(traceDerivedCustomTagKeys).containsExactlyInAnyOrder("region", "test");
+          Map<String, String> tags = (Map<String, String>) ReflectionTestUtils.getField(
+              spanHandler, "globalSpanTags");
+          assertThat(tags).containsExactlyInAnyOrderEntriesOf(Collections.singletonMap("hello",
+              "world"));
         });
   }
 
@@ -286,19 +295,72 @@ class WavefrontAutoConfigurationTests {
     this.contextRunner
         .withClassLoader(new FilteredClassLoader("org.springframework.cloud.sleuth"))
         .withPropertyValues("wavefront.tracing.red-metrics-custom-tag-keys=region,test")
+        .withPropertyValues("wavefront.tracing.tags.hello=world")
+        .withPropertyValues("wavefront.tracing.opentracing.sampler.probability=0.1")
+        .withPropertyValues("wavefront.tracing.opentracing.sampler.duration=2s")
         .with(wavefrontMetrics(() -> {
           WavefrontSender sender = mock(WavefrontSender.class);
           given(sender.getFailureCount()).willReturn(42);
           return sender;
-        })).run((context) -> {
-      assertThat(context).hasSingleBean(io.opentracing.Tracer.class).hasSingleBean(WavefrontTracer.class);
-      WavefrontTracer wavefrontTracer = context.getBean(WavefrontTracer.class);
-      Reporter reporter = (Reporter) ReflectionTestUtils.getField(wavefrontTracer, "reporter");
-      assertThat(reporter.getFailureCount()).isEqualTo(42);
-      Set<String> redMetricsCustomTagKeys = (Set<String>) ReflectionTestUtils.getField(wavefrontTracer,
-          "redMetricsCustomTagKeys");
-      assertThat(redMetricsCustomTagKeys).containsExactlyInAnyOrder("span.kind", "region", "test");
-    });
+        }))
+        .run((context) -> {
+          assertThat(context).hasSingleBean(io.opentracing.Tracer.class).hasSingleBean(WavefrontTracer.class);
+          WavefrontTracer wavefrontTracer = context.getBean(WavefrontTracer.class);
+          Reporter reporter = (Reporter) ReflectionTestUtils.getField(wavefrontTracer, "reporter");
+          assertThat(reporter.getFailureCount()).isEqualTo(42);
+          Set<String> redMetricsCustomTagKeys = (Set<String>) ReflectionTestUtils.getField(wavefrontTracer,
+              "redMetricsCustomTagKeys");
+          assertThat(redMetricsCustomTagKeys).containsExactlyInAnyOrder("span.kind", "region", "test");
+          List<Pair<String, String>> tags = (List<Pair<String, String>>) ReflectionTestUtils.getField(
+              wavefrontTracer, "tags");
+          assertThat(tags).contains(Pair.of("hello", "world"));
+          List<Sampler> samplers = (List<Sampler>) ReflectionTestUtils.getField(wavefrontTracer,
+              "samplers");
+          assertThat(samplers).hasSize(2);
+        });
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void tracingWithOpenTracingCanBeCustomized() {
+    this.contextRunner
+        .withClassLoader(new FilteredClassLoader("org.springframework.cloud.sleuth"))
+        .withPropertyValues("wavefront.tracing.red-metrics-custom-tag-keys=region,test")
+        .with(wavefrontMetrics(() -> {
+          WavefrontSender sender = mock(WavefrontSender.class);
+          given(sender.getFailureCount()).willReturn(42);
+          return sender;
+        }))
+        .withBean(WavefrontTracerBuilderCustomizer.class,
+            () -> (builder) -> builder.redMetricsCustomTagKeys(Collections.singleton("customized")))
+        .run((context) -> {
+          assertThat(context).hasSingleBean(io.opentracing.Tracer.class).hasSingleBean(WavefrontTracer.class);
+          WavefrontTracer wavefrontTracer = context.getBean(WavefrontTracer.class);
+          Reporter reporter = (Reporter) ReflectionTestUtils.getField(wavefrontTracer, "reporter");
+          assertThat(reporter.getFailureCount()).isEqualTo(42);
+          Set<String> redMetricsCustomTagKeys = (Set<String>) ReflectionTestUtils.getField(wavefrontTracer,
+              "redMetricsCustomTagKeys");
+          assertThat(redMetricsCustomTagKeys).containsExactlyInAnyOrder("span.kind", "region",
+              "test", "customized");
+        });
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void tracingWithOpenTracingWithCustomReporter() {
+    this.contextRunner
+        .withClassLoader(new FilteredClassLoader("org.springframework.cloud.sleuth"))
+        .with(wavefrontSpanReporter(() -> {
+          Reporter reporter = mock(Reporter.class);
+          given(reporter.getFailureCount()).willReturn(21);
+          return reporter;
+        }))
+        .run((context) -> {
+          assertThat(context).hasSingleBean(io.opentracing.Tracer.class).hasSingleBean(WavefrontTracer.class);
+          WavefrontTracer wavefrontTracer = context.getBean(WavefrontTracer.class);
+          Reporter reporter = (Reporter) ReflectionTestUtils.getField(wavefrontTracer, "reporter");
+          assertThat(reporter.getFailureCount()).isEqualTo(21);
+        });
   }
 
   @Test
@@ -341,6 +403,12 @@ class WavefrontAutoConfigurationTests {
   @SuppressWarnings("unchecked")
   private static <T extends AbstractApplicationContextRunner<?, ?, ?>> Function<T, T> sleuth() {
     return (runner) -> (T) runner.withConfiguration(AutoConfigurations.of(TraceAutoConfiguration.class));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T extends AbstractApplicationContextRunner<?, ?, ?>> Function<T, T> wavefrontSpanReporter(
+      Supplier<Reporter> reporter) {
+    return (runner) -> (T) runner.withBean(Reporter.class, reporter);
   }
 
 }

--- a/wavefront-spring-boot/src/test/java/com/wavefront/spring/autoconfigure/WavefrontTracingIntegrationTests.java
+++ b/wavefront-spring-boot/src/test/java/com/wavefront/spring/autoconfigure/WavefrontTracingIntegrationTests.java
@@ -59,7 +59,8 @@ import static org.assertj.core.api.Assertions.assertThat;
     classes = WavefrontTracingIntegrationTests.Config.class,
     properties = {
         "wavefront.application.name=IntegratedTracingTests",
-        "spring.application.name=test_service"
+        "spring.application.name=test_service",
+        "wavefront.tracing.tags.region=us-west"
     })
 @AutoConfigureWebTestClient
 @DirtiesContext
@@ -108,7 +109,8 @@ public class WavefrontTracingIntegrationTests {
         Pair.of("http.path", "/api/fn/10"),
         Pair.of("mvc.controller.class", "WebMvcController"),
         Pair.of("mvc.controller.method", "fn"),
-        Pair.of("span.kind", "server")
+        Pair.of("span.kind", "server"),
+        Pair.of("region", "us-west")
     );
   }
 

--- a/wavefront-spring-boot/src/test/java/com/wavefront/spring/autoconfigure/WavefrontTracingIntegrationTests.java
+++ b/wavefront-spring-boot/src/test/java/com/wavefront/spring/autoconfigure/WavefrontTracingIntegrationTests.java
@@ -59,8 +59,7 @@ import static org.assertj.core.api.Assertions.assertThat;
     classes = WavefrontTracingIntegrationTests.Config.class,
     properties = {
         "wavefront.application.name=IntegratedTracingTests",
-        "spring.application.name=test_service",
-        "wavefront.tracing.tags.region=us-west"
+        "spring.application.name=test_service"
     })
 @AutoConfigureWebTestClient
 @DirtiesContext
@@ -109,8 +108,7 @@ public class WavefrontTracingIntegrationTests {
         Pair.of("http.path", "/api/fn/10"),
         Pair.of("mvc.controller.class", "WebMvcController"),
         Pair.of("mvc.controller.method", "fn"),
-        Pair.of("span.kind", "server"),
-        Pair.of("region", "us-west")
+        Pair.of("span.kind", "server")
     );
   }
 


### PR DESCRIPTION
Adding some nice-to-have features to make configuration and customization of tracing (mostly OpenTracing) easier:
1. ~~Add configuration property to set global tags for spans.~~ Will address this in separate PR.
2. Add configuration properties to configure sampling for OpenTracing, since that already exists for Sleuth.
3. Support overriding of the default WavefrontSpanReporter.
4. Add customizer for WavefrontTracer.Builder to allow for any further customizations.