### PR TITLE
Provide starter version when interacting with the account management API

### DIFF
--- a/wavefront-spring-boot/pom.xml
+++ b/wavefront-spring-boot/pom.xml
@@ -81,4 +81,21 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+        <includes>
+          <include>META-INF/wavefront-spring-boot/build.properties</include>
+        </includes>
+      </resource>
+      <resource>
+        <directory>src/main/resources</directory>
+        <excludes>
+          <exclude>META-INF/wavefront-spring-boot/build.properties</exclude>
+        </excludes>
+      </resource>
+    </resources>
+  </build>
 </project>

--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/account/AccountManagementClient.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/account/AccountManagementClient.java
@@ -25,9 +25,19 @@ public class AccountManagementClient {
 
   private final RestTemplate restTemplate;
 
-  public AccountManagementClient(RestTemplateBuilder restTemplateBuilder) {
+  private final String version;
+
+  /**
+   * Create an instance using the specified {@link RestTemplateBuilder} and starter
+   * {@code version}.
+   * @param restTemplateBuilder the builder to use to configure the {@link RestTemplate}.
+   * @param version the version of the starter or {@code null} if the version could not
+   * be determined.
+   */
+  public AccountManagementClient(RestTemplateBuilder restTemplateBuilder, String version) {
     this.restTemplate = restTemplateBuilder.setConnectTimeout(Duration.ofSeconds(10))
         .setReadTimeout(Duration.ofSeconds(10)).build();
+    this.version = version;
   }
 
   /**
@@ -85,6 +95,9 @@ public class AccountManagementClient {
     }
     if (applicationTags.getShard() != null) {
       uriComponentsBuilder.queryParam("shard", applicationTags.getShard());
+    }
+    if (this.version != null) {
+      uriComponentsBuilder.queryParam("starterVersion", this.version);
     }
     return uriComponentsBuilder.build().toUri();
   }

--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/actuate/WavefrontEndpointAutoConfiguration.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/actuate/WavefrontEndpointAutoConfiguration.java
@@ -2,6 +2,7 @@ package com.wavefront.spring.actuate;
 
 import java.net.URI;
 
+import com.wavefront.sdk.common.Utils;
 import com.wavefront.sdk.common.application.ApplicationTags;
 import com.wavefront.spring.account.AccountManagementClient;
 import com.wavefront.spring.autoconfigure.WavefrontAutoConfiguration;
@@ -35,7 +36,8 @@ public class WavefrontEndpointAutoConfiguration {
   @Bean
   @ConditionalOnMissingBean
   public AccountManagementClient accountManagementClient(RestTemplateBuilder restTemplateBuilder) {
-    return new AccountManagementClient(restTemplateBuilder);
+    return new AccountManagementClient(restTemplateBuilder,
+        Utils.getVersion("wavefront-spring-boot").orElse(null));
   }
 
   @Bean

--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/AccountManagementEnvironmentPostProcessor.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/AccountManagementEnvironmentPostProcessor.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
+import com.wavefront.sdk.common.Utils;
 import com.wavefront.sdk.common.application.ApplicationTags;
 import com.wavefront.spring.account.AccountInfo;
 import com.wavefront.spring.account.AccountManagementClient;
@@ -219,7 +220,8 @@ class AccountManagementEnvironmentPostProcessor
   private AccountInfo invokeAccountManagementClient(ConfigurableEnvironment environment,
       BiFunction<AccountManagementClient, ApplicationTags, AccountInfo> accountProvider) {
     RestTemplateBuilder restTemplateBuilder = new RestTemplateBuilder();
-    AccountManagementClient client = new AccountManagementClient(restTemplateBuilder);
+    AccountManagementClient client = new AccountManagementClient(restTemplateBuilder,
+        Utils.getVersion("wavefront-spring-boot").orElse(null));
     ApplicationTags applicationTags = new ApplicationTagsFactory().createFromEnvironment(environment);
     return accountProvider.apply(client, applicationTags);
   }

--- a/wavefront-spring-boot/src/main/resources/META-INF/wavefront-spring-boot/build.properties
+++ b/wavefront-spring-boot/src/main/resources/META-INF/wavefront-spring-boot/build.properties
@@ -1,0 +1,1 @@
+project.version=${project.version}


### PR DESCRIPTION
This commit provides an additional "starterVersion" request parameter
when interacting with the account management API. If no version is
available, the attribute is not set.