### PR TITLE
Upgrade to Spring Boot 2.6.0-M1 and Spring Cloud 2021.0.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.wavefront</groupId>
   <artifactId>wavefront-spring-boot-build</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.3.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Wavefront Spring Boot Build</name>
   <description>Wavefront by VMware integration for Spring Boot</description>

--- a/wavefront-spring-boot-bom/pom.xml
+++ b/wavefront-spring-boot-bom/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.wavefront</groupId>
     <artifactId>wavefront-spring-boot-build</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
   <artifactId>wavefront-spring-boot-bom</artifactId>

--- a/wavefront-spring-boot-parent/pom.xml
+++ b/wavefront-spring-boot-parent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.wavefront</groupId>
     <artifactId>wavefront-spring-boot-bom</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
     <relativePath>../wavefront-spring-boot-bom</relativePath>
   </parent>
   <artifactId>wavefront-spring-boot-parent</artifactId>

--- a/wavefront-spring-boot-parent/pom.xml
+++ b/wavefront-spring-boot-parent/pom.xml
@@ -19,8 +19,8 @@
 
   <properties>
     <java.version>1.8</java.version>
-    <spring-boot.version>2.5.0</spring-boot.version>
-    <spring-cloud.version>2020.0.3</spring-cloud.version>
+    <spring-boot.version>2.6.0-M1</spring-boot.version>
+    <spring-cloud.version>2021.0.0-SNAPSHOT</spring-cloud.version>
   </properties>
 
   <dependencyManagement>

--- a/wavefront-spring-boot-sample/pom.xml
+++ b/wavefront-spring-boot-sample/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.wavefront</groupId>
     <artifactId>wavefront-spring-boot-parent</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
     <relativePath>../wavefront-spring-boot-parent</relativePath>
   </parent>
   <artifactId>wavefront-spring-boot-sample</artifactId>

--- a/wavefront-spring-boot-starter/pom.xml
+++ b/wavefront-spring-boot-starter/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.wavefront</groupId>
     <artifactId>wavefront-spring-boot-parent</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
     <relativePath>../wavefront-spring-boot-parent</relativePath>
   </parent>
   <artifactId>wavefront-spring-boot-starter</artifactId>

--- a/wavefront-spring-boot/pom.xml
+++ b/wavefront-spring-boot/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.wavefront</groupId>
     <artifactId>wavefront-spring-boot-parent</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
     <relativePath>../wavefront-spring-boot-parent</relativePath>
   </parent>
   <artifactId>wavefront-spring-boot</artifactId>


### PR DESCRIPTION
Spring Boot and Spring Cloud must be upgraded concurrently to get the test suite to pass. Also bumped our version to 2.3.0-SNAPSHOT.