### PR TITLE
Remove "_spanSecondaryId" tag

### DIFF
--- a/wavefront-spring-boot-sample/pom.xml
+++ b/wavefront-spring-boot-sample/pom.xml
@@ -29,7 +29,6 @@
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-sleuth</artifactId>
-      <scope>runtime</scope>
     </dependency>
 
     <dependency>

--- a/wavefront-spring-boot-sample/src/main/java/sample/ServletFilter.java
+++ b/wavefront-spring-boot-sample/src/main/java/sample/ServletFilter.java
@@ -1,0 +1,41 @@
+package sample;
+
+import org.springframework.cloud.sleuth.Span;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.GenericFilterBean;
+import org.springframework.cloud.sleuth.Tracer;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import java.io.IOException;
+
+@Component
+public class ServletFilter extends GenericFilterBean {
+
+    private final Tracer tracer;
+
+    public ServletFilter(Tracer tracer) {
+        this.tracer = tracer;
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        Span currentSpan = this.tracer.currentSpan();
+
+        if (currentSpan == null) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        try {
+            chain.doFilter(request, response);
+        }
+        catch (Exception e) {
+            currentSpan.event(String.valueOf(e));
+            throw e;
+        }
+    }
+}

--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontSleuthSpanHandler.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontSleuthSpanHandler.java
@@ -329,9 +329,6 @@ public final class WavefrontSleuthSpanHandler implements Runnable, Closeable {
       if (span.getKind() != null) {
         String kind = span.getKind().toString().toLowerCase();
         add(Pair.of("span.kind", kind));
-        if (hasAnnotations) {
-          add(Pair.of("_spanSecondaryId", kind));
-        }
       }
 
       // https://github.com/wavefrontHQ/wavefront-proxy/blob/3dd1fa11711a04de2d9d418e2269f0f9fb464f36/proxy/src/main/java/com/wavefront/agent/listeners/tracing/ZipkinPortUnificationHandler.java#L329-L332


### PR DESCRIPTION
Related to #143
After removing "_spanSecondaryId" tag.
Run
```
./mvnw spring-boot:run -pl wavefront-spring-boot-sample             
```
Then access localhost:8080/oops.
span.event now visible in TObs UI.

![image](https://user-images.githubusercontent.com/67083789/151975621-5f5d9c9f-6632-48b9-9916-fc159b3c1a66.png)
