### PR TITLE
MONIT-27404: increase read timeout

### DIFF
--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/account/AccountManagementClient.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/account/AccountManagementClient.java
@@ -35,8 +35,8 @@ public class AccountManagementClient {
    * be determined.
    */
   public AccountManagementClient(RestTemplateBuilder restTemplateBuilder, String version) {
-    this.restTemplate = restTemplateBuilder.setConnectTimeout(Duration.ofSeconds(10))
-        .setReadTimeout(Duration.ofSeconds(10)).build();
+    this.restTemplate = restTemplateBuilder.setConnectTimeout(Duration.ofSeconds(20))
+        .setReadTimeout(Duration.ofSeconds(20)).build();
     this.version = version;
   }
 


### PR DESCRIPTION
Provision an account from Wavefront application now takes longer and causes timeout. In this request, we increase the timeout from 10 seconds to 20 seconds.