### PR TITLE
Add custom tags to properties

### DIFF
--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/ApplicationTagsFactory.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/ApplicationTagsFactory.java
@@ -53,6 +53,7 @@ public class ApplicationTagsFactory {
     PropertyMapper mapper = PropertyMapper.get().alwaysApplyingWhenNonNull();
     mapper.from(application::getCluster).to(builder::cluster);
     mapper.from(application::getShard).to(builder::shard);
+    mapper.from(application::getCustomTags).to(builder::customTags);
     return customize(builder).build();
   }
 

--- a/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontProperties.java
+++ b/wavefront-spring-boot/src/main/java/com/wavefront/spring/autoconfigure/WavefrontProperties.java
@@ -2,6 +2,7 @@ package com.wavefront.spring.autoconfigure;
 
 import java.time.Duration;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -72,6 +73,8 @@ public class WavefrontProperties {
      */
     private String shard;
 
+    private Map<String, String> customTags;
+
     public String getName() {
       return this.name;
     }
@@ -104,6 +107,13 @@ public class WavefrontProperties {
       this.shard = shard;
     }
 
+    public Map<String, String> getCustomTags() {
+      return customTags;
+    }
+
+    public void setCustomTags(Map<String, String> customTags) {
+      this.customTags = customTags;
+    }
   }
 
   public static class Metrics {

--- a/wavefront-spring-boot/src/test/java/com/wavefront/spring/autoconfigure/AccountManagementEnvironmentPostProcessorTests.java
+++ b/wavefront-spring-boot/src/test/java/com/wavefront/spring/autoconfigure/AccountManagementEnvironmentPostProcessorTests.java
@@ -127,7 +127,7 @@ class AccountManagementEnvironmentPostProcessorTests {
         .forExistingAccount(mock(Resource.class), () -> new AccountInfo("abc-def", "https://wavefront.surf/us/test1"));
     postProcessor.postProcessEnvironment(environment, this.application);
     postProcessor.onApplicationEvent(mockApplicationStartedEvent());
-    assertThat(output).contains("Connect to your Wavefront dashboard using this one-time use link:\n"
+    assertThat(output).containsIgnoringWhitespaces("Connect to your Wavefront dashboard using this one-time use link:\n"
         + "https://wavefront.surf/us/test1\n");
   }
 
@@ -142,7 +142,7 @@ class AccountManagementEnvironmentPostProcessorTests {
     assertThat(environment.getProperty(URI_PROPERTY)).isEqualTo("https://wavefront.surf");
     assertThat(environment.getProperty(FREEMIUM_ACCOUNT_PROPERTY)).isEqualTo("true");
     postProcessor.onApplicationEvent(mockApplicationStartedEvent());
-    assertThat(output).contains("Your existing Wavefront account information has been restored from disk.\n" + "\n"
+    assertThat(output).containsIgnoringWhitespaces("Your existing Wavefront account information has been restored from disk.\n" + "\n"
         + "To share this account, make sure the following is added to your configuration:\n\n"
         + "\tmanagement.metrics.export.wavefront.api-token=abc-def\n"
         + "\tmanagement.metrics.export.wavefront.uri=https://wavefront.surf\n\n"
@@ -175,7 +175,7 @@ class AccountManagementEnvironmentPostProcessorTests {
     postProcessor.postProcessEnvironment(environment, this.application);
     postProcessor.onApplicationEvent(mockApplicationStartedEvent());
     assertThat(output)
-        .contains("Failed to retrieve existing account information from https://example.com. The error was:\n"
+        .containsIgnoringWhitespaces("Failed to retrieve existing account information from https://example.com. The error was:\n"
             + "\n" + "test message\n");
   }
 
@@ -193,7 +193,7 @@ class AccountManagementEnvironmentPostProcessorTests {
     assertThat(apiTokenFile).exists();
     assertThat(apiTokenFile).hasContent("abc-def");
     postProcessor.onApplicationEvent(mockApplicationStartedEvent());
-    assertThat(output).contains(
+    assertThat(output).containsIgnoringWhitespaces(
         "A Wavefront account has been provisioned successfully and the API token has been saved to disk.\n\n"
             + "To share this account, make sure the following is added to your configuration:\n\n"
             + "\tmanagement.metrics.export.wavefront.api-token=abc-def\n"
@@ -216,7 +216,7 @@ class AccountManagementEnvironmentPostProcessorTests {
     verifyNoMoreInteractions(apiTokenResource);
     postProcessor.onApplicationEvent(mockApplicationStartedEvent());
     assertThat(output)
-        .contains("Failed to auto-negotiate a Wavefront api token from https://wavefront.surf. The error was:\n"
+        .containsIgnoringWhitespaces("Failed to auto-negotiate a Wavefront api token from https://wavefront.surf. The error was:\n"
             + "\n" + "test message\n");
   }
 

--- a/wavefront-spring-boot/src/test/java/com/wavefront/spring/autoconfigure/WavefrontAutoConfigurationTests.java
+++ b/wavefront-spring-boot/src/test/java/com/wavefront/spring/autoconfigure/WavefrontAutoConfigurationTests.java
@@ -118,13 +118,13 @@ class WavefrontAutoConfigurationTests {
     this.contextRunner
         .withPropertyValues("wavefront.application.name=test-app",
             "wavefront.application.service=test-service", "wavefront.application.cluster=test-cluster",
-            "wavefront.application.shard=test-shard")
+            "wavefront.application.shard=test-shard", "wavefront.application.custom-tags.foo=bar")
         .with(wavefrontMetrics(() -> mock(WavefrontSender.class))).run((context) -> {
       MeterRegistry registry = context.getBean(MeterRegistry.class);
       registry.counter("my.counter", "env", "qa");
       assertThat(registry.find("my.counter").tags("env", "qa").tags("application", "test-app")
           .tags("service", "test-service").tags("cluster", "test-cluster").tags("shard", "test-shard")
-          .counter()).isNotNull();
+          .tags("foo", "bar").counter()).isNotNull();
     });
   }
 


### PR DESCRIPTION
allow adding custom tags through the WavefrontProperties.Application configuration object, aligning with ApplicationTags already containing a customTags field

